### PR TITLE
Add ielts vocabulary and collocations

### DIFF
--- a/ielts-vocabulary-app/backend/src/user/interfaces/user.interface.ts
+++ b/ielts-vocabulary-app/backend/src/user/interfaces/user.interface.ts
@@ -6,8 +6,8 @@ export interface User {
   email: string;
   name: string;
   avatar?: string;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
 }
 
 export interface UserProgress {
@@ -19,6 +19,6 @@ export interface UserProgress {
   correctCount: number;
   incorrectCount: number;
   lastReviewedAt?: Date;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt?: Date;
+  updatedAt?: Date;
 }

--- a/ielts-vocabulary-app/backend/src/user/user.service.ts
+++ b/ielts-vocabulary-app/backend/src/user/user.service.ts
@@ -24,17 +24,17 @@ export class UserService {
 
   async findByEmail(email: string): Promise<User | null> {
     const db = this.databaseService.getDb();
-    return await db.collection('users').findOne({ email });
+    return await db.collection('users').findOne({ email }) as User | null;
   }
 
   async findByGoogleId(googleId: string): Promise<User | null> {
     const db = this.databaseService.getDb();
-    return await db.collection('users').findOne({ googleId });
+    return await db.collection('users').findOne({ googleId }) as User | null;
   }
 
   async findById(id: string): Promise<User | null> {
     const db = this.databaseService.getDb();
-    return await db.collection('users').findOne({ _id: new ObjectId(id) });
+    return await db.collection('users').findOne({ _id: new ObjectId(id) }) as User | null;
   }
 
   async updateProgress(userId: string, vocabularyId: string, correct: boolean): Promise<UserProgress> {
@@ -67,7 +67,7 @@ export class UserService {
         { $set: updateData }
       );
 
-      return { ...existingProgress, ...updateData };
+      return { ...existingProgress, ...updateData } as UserProgress;
     } else {
       const newProgress: UserProgress = {
         userId: new ObjectId(userId),
@@ -90,7 +90,7 @@ export class UserService {
     const db = this.databaseService.getDb();
     return await db.collection('userProgress')
       .find({ userId: new ObjectId(userId) })
-      .toArray();
+      .toArray() as UserProgress[];
   }
 
   async getDueVocabulary(userId: string): Promise<any[]> {

--- a/ielts-vocabulary-app/backend/src/vocabulary/interfaces/vocabulary.interface.ts
+++ b/ielts-vocabulary-app/backend/src/vocabulary/interfaces/vocabulary.interface.ts
@@ -7,13 +7,13 @@ export interface Vocabulary {
   partOfSpeech: string;
   definition: string;
   example: string;
-  synonyms: string[];
-  antonyms: string[];
-  collocations: Collocation[];
+  synonyms?: string[];
+  antonyms?: string[];
+  collocations?: Collocation[];
   difficulty: 'beginner' | 'intermediate' | 'advanced';
-  topics: string[];
-  createdAt: Date;
-  updatedAt: Date;
+  topics?: string[];
+  createdAt?: Date;
+  updatedAt?: Date;
 }
 
 export interface Collocation {

--- a/ielts-vocabulary-app/backend/src/vocabulary/vocabulary-seeder.service.ts
+++ b/ielts-vocabulary-app/backend/src/vocabulary/vocabulary-seeder.service.ts
@@ -1,0 +1,1053 @@
+import { Injectable } from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import { Vocabulary } from './interfaces/vocabulary.interface';
+
+@Injectable()
+export class VocabularySeederService {
+  constructor(private databaseService: DatabaseService) {}
+
+  async seedIeltsVocabulary(): Promise<void> {
+    const db = this.databaseService.getDb();
+    
+    // Check if IELTS vocabulary already exists
+    const existingCount = await db.collection('vocabulary').countDocuments({
+      topics: { $in: ['ielts-writing', 'ielts-speaking'] }
+    });
+
+    if (existingCount < 50) { // Only seed if we don't have enough IELTS vocabulary
+      const ieltsVocabulary = this.getIeltsVocabularyPackages();
+      await db.collection('vocabulary').insertMany(ieltsVocabulary);
+      console.log(`Seeded ${ieltsVocabulary.length} IELTS vocabulary words`);
+    }
+  }
+
+  private getIeltsVocabularyPackages(): Vocabulary[] {
+    const now = new Date();
+    return [
+      // IELTS Writing Task 2 - Essential Academic Vocabulary
+      {
+        word: "significant",
+        pronunciation: "/sɪɡˈnɪfɪkənt/",
+        partOfSpeech: "adjective",
+        definition: "sufficiently great or important to be worthy of attention; noteworthy",
+        example: "There has been a significant increase in online learning.",
+        synonyms: ["important", "notable", "considerable", "substantial"],
+        antonyms: ["insignificant", "minor", "trivial"],
+        collocations: [
+          {
+            phrase: "significant impact",
+            definition: "a notable effect or influence",
+            example: "Climate change has a significant impact on global agriculture."
+          },
+          {
+            phrase: "significant difference",
+            definition: "a notable distinction or variation",
+            example: "There is a significant difference between online and traditional education."
+          },
+          {
+            phrase: "significant increase",
+            definition: "a notable rise or growth",
+            example: "The city experienced a significant increase in population."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["ielts-writing", "academic", "statistics"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "consequently",
+        pronunciation: "/ˈkɒnsɪkwəntli/",
+        partOfSpeech: "adverb",
+        definition: "as a result; therefore",
+        example: "The weather was bad; consequently, the match was cancelled.",
+        synonyms: ["therefore", "thus", "as a result", "hence"],
+        antonyms: [],
+        collocations: [
+          {
+            phrase: "consequently lead to",
+            definition: "to result in something as an outcome",
+            example: "Poor diet can consequently lead to health problems."
+          },
+          {
+            phrase: "consequently affect",
+            definition: "to influence as a result",
+            example: "Economic changes consequently affect employment rates."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["ielts-writing", "academic", "linking words"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "furthermore",
+        pronunciation: "/ˈfɜːðəmɔː/",
+        partOfSpeech: "adverb",
+        definition: "in addition; moreover",
+        example: "The plan is cost-effective. Furthermore, it's environmentally friendly.",
+        synonyms: ["moreover", "additionally", "besides", "in addition"],
+        antonyms: [],
+        collocations: [
+          {
+            phrase: "furthermore argue",
+            definition: "to add another point to an argument",
+            example: "Critics furthermore argue that the policy is unfair."
+          },
+          {
+            phrase: "furthermore suggest",
+            definition: "to add another suggestion or proposal",
+            example: "Experts furthermore suggest implementing stricter regulations."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["ielts-writing", "academic", "linking words"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "nevertheless",
+        pronunciation: "/ˌnevəðəˈles/",
+        partOfSpeech: "adverb",
+        definition: "in spite of that; however",
+        example: "The task was difficult; nevertheless, we completed it on time.",
+        synonyms: ["however", "nonetheless", "yet", "still"],
+        antonyms: [],
+        collocations: [
+          {
+            phrase: "nevertheless important",
+            definition: "still significant despite other factors",
+            example: "The research is limited; nevertheless, it provides important insights."
+          },
+          {
+            phrase: "nevertheless continue",
+            definition: "to persist despite obstacles",
+            example: "Despite the challenges, we will nevertheless continue our efforts."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["ielts-writing", "academic", "linking words"],
+        createdAt: now,
+        updatedAt: now,
+      },
+
+      // Environment & Sustainability - Extended Vocabulary
+      {
+        word: "renewable",
+        pronunciation: "/rɪˈnjuːəbəl/",
+        partOfSpeech: "adjective",
+        definition: "able to be renewed; relating to energy from sources that are naturally replenished",
+        example: "Solar power is a renewable energy source.",
+        synonyms: ["sustainable", "regenerative", "inexhaustible"],
+        antonyms: ["non-renewable", "finite", "exhaustible"],
+        collocations: [
+          {
+            phrase: "renewable energy",
+            definition: "energy from sources that naturally replenish",
+            example: "Many countries are investing in renewable energy technologies."
+          },
+          {
+            phrase: "renewable resources",
+            definition: "natural resources that can be replenished",
+            example: "Wind and solar are examples of renewable resources."
+          },
+          {
+            phrase: "renewable technology",
+            definition: "technology that uses sustainable energy sources",
+            example: "Advances in renewable technology are reducing costs significantly."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["environment", "energy", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "biodiversity",
+        pronunciation: "/ˌbaɪəʊdaɪˈvɜːsəti/",
+        partOfSpeech: "noun",
+        definition: "the variety of plant and animal life in the world or in a particular habitat",
+        example: "Deforestation threatens biodiversity in tropical regions.",
+        synonyms: ["biological diversity", "ecological variety"],
+        antonyms: ["monoculture", "uniformity"],
+        collocations: [
+          {
+            phrase: "protect biodiversity",
+            definition: "to preserve variety in ecosystems",
+            example: "National parks help protect biodiversity for future generations."
+          },
+          {
+            phrase: "biodiversity loss",
+            definition: "the reduction of variety in living organisms",
+            example: "Climate change is accelerating biodiversity loss worldwide."
+          },
+          {
+            phrase: "rich biodiversity",
+            definition: "high variety of species in an area",
+            example: "Rainforests are known for their rich biodiversity."
+          }
+        ],
+        difficulty: "advanced",
+        topics: ["environment", "biology", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "conservation",
+        pronunciation: "/ˌkɒnsəˈveɪʃən/",
+        partOfSpeech: "noun",
+        definition: "the protection of plants, animals, and natural areas",
+        example: "Wildlife conservation is essential for maintaining ecosystems.",
+        synonyms: ["preservation", "protection", "maintenance"],
+        antonyms: ["destruction", "waste", "depletion"],
+        collocations: [
+          {
+            phrase: "wildlife conservation",
+            definition: "protection of animals and their habitats",
+            example: "Wildlife conservation efforts have saved many endangered species."
+          },
+          {
+            phrase: "conservation efforts",
+            definition: "activities aimed at protecting the environment",
+            example: "International conservation efforts are needed to address climate change."
+          },
+          {
+            phrase: "energy conservation",
+            definition: "reducing energy consumption to preserve resources",
+            example: "Energy conservation in buildings can significantly reduce carbon emissions."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["environment", "wildlife", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+
+      // Technology & Digital Age - Extended Vocabulary
+      {
+        word: "artificial intelligence",
+        pronunciation: "/ˌɑːtɪˈfɪʃəl ɪnˈtelɪdʒəns/",
+        partOfSpeech: "noun",
+        definition: "the simulation of human intelligence in machines",
+        example: "Artificial intelligence is transforming many industries.",
+        synonyms: ["AI", "machine intelligence", "computer intelligence"],
+        antonyms: ["human intelligence", "natural intelligence"],
+        collocations: [
+          {
+            phrase: "artificial intelligence technology",
+            definition: "systems that simulate human thinking",
+            example: "Artificial intelligence technology is advancing rapidly in healthcare."
+          },
+          {
+            phrase: "develop artificial intelligence",
+            definition: "to create AI systems",
+            example: "Tech companies invest billions to develop artificial intelligence."
+          },
+          {
+            phrase: "artificial intelligence applications",
+            definition: "practical uses of AI technology",
+            example: "Artificial intelligence applications include voice recognition and autonomous vehicles."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["technology", "future", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "automation",
+        pronunciation: "/ˌɔːtəˈmeɪʃən/",
+        partOfSpeech: "noun",
+        definition: "the use of machines or computers to do work that was previously done by people",
+        example: "Automation in factories has increased productivity but reduced jobs.",
+        synonyms: ["mechanization", "computerization", "robotization"],
+        antonyms: ["manual work", "human labor"],
+        collocations: [
+          {
+            phrase: "workplace automation",
+            definition: "using machines to replace human workers",
+            example: "Workplace automation is changing the nature of employment."
+          },
+          {
+            phrase: "automation technology",
+            definition: "systems that perform tasks automatically",
+            example: "Advances in automation technology are revolutionizing manufacturing."
+          },
+          {
+            phrase: "job automation",
+            definition: "replacing human jobs with machines",
+            example: "Job automation may lead to unemployment in some sectors."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["technology", "work", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+
+      // Education & Learning - Extended Vocabulary
+      {
+        word: "pedagogy",
+        pronunciation: "/ˈpedəɡɒdʒi/",
+        partOfSpeech: "noun",
+        definition: "the method and practice of teaching",
+        example: "Modern pedagogy emphasizes student-centered learning approaches.",
+        synonyms: ["teaching methods", "educational practice", "instruction"],
+        antonyms: [],
+        collocations: [
+          {
+            phrase: "effective pedagogy",
+            definition: "successful teaching methods",
+            example: "Effective pedagogy adapts to different learning styles."
+          },
+          {
+            phrase: "digital pedagogy",
+            definition: "teaching methods using technology",
+            example: "Digital pedagogy has become essential in online education."
+          },
+          {
+            phrase: "pedagogy research",
+            definition: "studies on teaching methods",
+            example: "Pedagogy research helps improve educational outcomes."
+          }
+        ],
+        difficulty: "advanced",
+        topics: ["education", "teaching", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "competency",
+        pronunciation: "/ˈkɒmpɪtənsi/",
+        partOfSpeech: "noun",
+        definition: "the ability to do something successfully or efficiently",
+        example: "Digital competency is essential for modern students.",
+        synonyms: ["skill", "ability", "proficiency", "expertise"],
+        antonyms: ["incompetence", "inability"],
+        collocations: [
+          {
+            phrase: "develop competency",
+            definition: "to build skills and abilities",
+            example: "Students need to develop competency in critical thinking."
+          },
+          {
+            phrase: "core competency",
+            definition: "essential skills or abilities",
+            example: "Communication is a core competency for all professionals."
+          },
+          {
+            phrase: "competency assessment",
+            definition: "evaluation of skills and abilities",
+            example: "Regular competency assessment helps track student progress."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["education", "skills", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+
+      // Health & Wellbeing - Extended Vocabulary
+      {
+        word: "epidemic",
+        pronunciation: "/ˌepɪˈdemɪk/",
+        partOfSpeech: "noun",
+        definition: "a widespread occurrence of an infectious disease in a community",
+        example: "The flu epidemic affected thousands of people last winter.",
+        synonyms: ["outbreak", "pandemic", "plague"],
+        antonyms: ["endemic", "isolated case"],
+        collocations: [
+          {
+            phrase: "epidemic outbreak",
+            definition: "the sudden start of widespread disease",
+            example: "Health officials work to prevent epidemic outbreaks."
+          },
+          {
+            phrase: "control epidemic",
+            definition: "to manage and stop disease spread",
+            example: "Vaccination programs help control epidemic diseases."
+          },
+          {
+            phrase: "epidemic prevention",
+            definition: "measures to stop disease outbreaks",
+            example: "Good hygiene is essential for epidemic prevention."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["health", "medicine", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "mental health",
+        pronunciation: "/ˈmentəl helθ/",
+        partOfSpeech: "noun",
+        definition: "a person's condition with regard to their psychological and emotional well-being",
+        example: "Workplace stress can significantly impact mental health.",
+        synonyms: ["psychological health", "emotional wellbeing"],
+        antonyms: ["mental illness", "psychological disorder"],
+        collocations: [
+          {
+            phrase: "mental health awareness",
+            definition: "understanding and recognition of psychological wellbeing",
+            example: "Mental health awareness campaigns reduce stigma and encourage treatment."
+          },
+          {
+            phrase: "mental health support",
+            definition: "assistance for psychological wellbeing",
+            example: "Schools should provide mental health support for students."
+          },
+          {
+            phrase: "mental health issues",
+            definition: "problems related to psychological wellbeing",
+            example: "Social media can contribute to mental health issues among teenagers."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["health", "psychology", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+
+      // Economics & Business - Extended Vocabulary
+      {
+        word: "globalization",
+        pronunciation: "/ˌɡləʊbəlaɪˈzeɪʃən/",
+        partOfSpeech: "noun",
+        definition: "the process by which businesses develop international influence",
+        example: "Globalization has connected markets around the world.",
+        synonyms: ["internationalization", "worldwide integration"],
+        antonyms: ["localization", "isolation"],
+        collocations: [
+          {
+            phrase: "economic globalization",
+            definition: "worldwide economic integration",
+            example: "Economic globalization has increased trade between countries."
+          },
+          {
+            phrase: "effects of globalization",
+            definition: "consequences of worldwide integration",
+            example: "The effects of globalization include both opportunities and challenges."
+          },
+          {
+            phrase: "globalization process",
+            definition: "the way worldwide integration occurs",
+            example: "Technology has accelerated the globalization process."
+          }
+        ],
+        difficulty: "advanced",
+        topics: ["economics", "business", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "entrepreneurship",
+        pronunciation: "/ˌɒntrəprəˈnɜːʃɪp/",
+        partOfSpeech: "noun",
+        definition: "the activity of setting up a business, taking financial risks for profit",
+        example: "The government encourages entrepreneurship through tax incentives.",
+        synonyms: ["business creation", "enterprise", "innovation"],
+        antonyms: ["employment", "wage work"],
+        collocations: [
+          {
+            phrase: "promote entrepreneurship",
+            definition: "to encourage business creation",
+            example: "Universities promote entrepreneurship through startup programs."
+          },
+          {
+            phrase: "entrepreneurship education",
+            definition: "teaching business creation skills",
+            example: "Entrepreneurship education prepares students for self-employment."
+          },
+          {
+            phrase: "social entrepreneurship",
+            definition: "creating businesses to solve social problems",
+            example: "Social entrepreneurship combines profit with positive social impact."
+          }
+        ],
+        difficulty: "advanced",
+        topics: ["business", "economics", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+
+      // More Essential Phrasal Verbs for IELTS
+      {
+        word: "come across",
+        pronunciation: "/kʌm əˈkrɒs/",
+        partOfSpeech: "phrasal verb",
+        definition: "to find or encounter by chance; to seem or appear",
+        example: "I came across an interesting article about climate change.",
+        synonyms: ["encounter", "find", "discover", "meet"],
+        antonyms: ["avoid", "miss"],
+        collocations: [
+          {
+            phrase: "come across information",
+            definition: "to find data or facts by chance",
+            example: "Researchers often come across unexpected information during studies."
+          },
+          {
+            phrase: "come across as",
+            definition: "to appear or seem to be",
+            example: "The speaker came across as very knowledgeable about the topic."
+          },
+          {
+            phrase: "come across problems",
+            definition: "to encounter difficulties",
+            example: "Students may come across problems when learning a new language."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["phrasal verbs", "ielts-speaking", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "look into",
+        pronunciation: "/lʊk ˈɪntuː/",
+        partOfSpeech: "phrasal verb",
+        definition: "to investigate or examine something",
+        example: "The government will look into the causes of pollution.",
+        synonyms: ["investigate", "examine", "research", "study"],
+        antonyms: ["ignore", "overlook"],
+        collocations: [
+          {
+            phrase: "look into the matter",
+            definition: "to investigate a situation or problem",
+            example: "The committee will look into the matter of student complaints."
+          },
+          {
+            phrase: "look into possibilities",
+            definition: "to explore potential options",
+            example: "We should look into possibilities for renewable energy."
+          },
+          {
+            phrase: "look into causes",
+            definition: "to investigate reasons or origins",
+            example: "Scientists look into causes of climate change."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["phrasal verbs", "investigation", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "point out",
+        pronunciation: "/pɔɪnt aʊt/",
+        partOfSpeech: "phrasal verb",
+        definition: "to direct attention to something; to mention or indicate",
+        example: "The teacher pointed out the students' mistakes.",
+        synonyms: ["indicate", "highlight", "mention", "show"],
+        antonyms: ["ignore", "conceal"],
+        collocations: [
+          {
+            phrase: "point out problems",
+            definition: "to identify and mention difficulties",
+            example: "Critics point out problems with the new education policy."
+          },
+          {
+            phrase: "point out benefits",
+            definition: "to highlight advantages",
+            example: "Supporters point out benefits of renewable energy."
+          },
+          {
+            phrase: "point out that",
+            definition: "to mention or state that",
+            example: "Experts point out that exercise improves mental health."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["phrasal verbs", "communication", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "set up",
+        pronunciation: "/set ʌp/",
+        partOfSpeech: "phrasal verb",
+        definition: "to establish or create something; to arrange or organize",
+        example: "The company plans to set up a new branch in Asia.",
+        synonyms: ["establish", "create", "found", "organize"],
+        antonyms: ["dismantle", "close down"],
+        collocations: [
+          {
+            phrase: "set up a business",
+            definition: "to start or establish a company",
+            example: "Many graduates want to set up their own business."
+          },
+          {
+            phrase: "set up a system",
+            definition: "to create or organize a method or process",
+            example: "Schools need to set up effective online learning systems."
+          },
+          {
+            phrase: "set up meetings",
+            definition: "to arrange or organize gatherings",
+            example: "The manager will set up meetings with all department heads."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["phrasal verbs", "business", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+
+      // IELTS Speaking - Opinion and Discussion Vocabulary
+      {
+        word: "perspective",
+        pronunciation: "/pəˈspektɪv/",
+        partOfSpeech: "noun",
+        definition: "a particular attitude toward or way of regarding something; a point of view",
+        example: "From my perspective, education should be free for everyone.",
+        synonyms: ["viewpoint", "standpoint", "outlook", "angle"],
+        antonyms: [],
+        collocations: [
+          {
+            phrase: "different perspective",
+            definition: "an alternative viewpoint or way of thinking",
+            example: "Traveling gives you a different perspective on life."
+          },
+          {
+            phrase: "from this perspective",
+            definition: "considering this viewpoint",
+            example: "From this perspective, the policy makes perfect sense."
+          },
+          {
+            phrase: "broader perspective",
+            definition: "a wider or more comprehensive viewpoint",
+            example: "We need a broader perspective to solve global problems."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["opinion", "discussion", "ielts-speaking", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "controversy",
+        pronunciation: "/ˈkɒntrəvɜːsi/",
+        partOfSpeech: "noun",
+        definition: "disagreement or argument about something important",
+        example: "The new law has caused considerable controversy.",
+        synonyms: ["debate", "dispute", "argument", "disagreement"],
+        antonyms: ["agreement", "consensus", "harmony"],
+        collocations: [
+          {
+            phrase: "cause controversy",
+            definition: "to create disagreement or debate",
+            example: "The politician's comments caused controversy in the media."
+          },
+          {
+            phrase: "avoid controversy",
+            definition: "to stay away from disagreement or conflict",
+            example: "Companies often try to avoid controversy in their advertising."
+          },
+          {
+            phrase: "controversial issue",
+            definition: "a topic that causes disagreement",
+            example: "Climate change policies remain a controversial issue."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["debate", "politics", "ielts-speaking", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+
+      // Additional Academic Word List (AWL) - Essential for IELTS Band 6.5
+      {
+        word: "approach",
+        pronunciation: "/əˈprəʊtʃ/",
+        partOfSpeech: "noun/verb",
+        definition: "a way of dealing with something; to come near or nearer to",
+        example: "The government adopted a new approach to education reform.",
+        synonyms: ["method", "strategy", "technique", "way"],
+        antonyms: ["avoidance", "retreat"],
+        collocations: [
+          {
+            phrase: "systematic approach",
+            definition: "an organized and methodical way of doing something",
+            example: "A systematic approach to learning vocabulary improves retention."
+          },
+          {
+            phrase: "approach the problem",
+            definition: "to deal with or tackle an issue",
+            example: "Scientists approach the problem from different angles."
+          },
+          {
+            phrase: "innovative approach",
+            definition: "a new and creative method",
+            example: "The school uses an innovative approach to language teaching."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["academic", "methodology", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "concept",
+        pronunciation: "/ˈkɒnsept/",
+        partOfSpeech: "noun",
+        definition: "an abstract idea or general notion",
+        example: "The concept of sustainable development is widely accepted.",
+        synonyms: ["idea", "notion", "principle", "theory"],
+        antonyms: ["reality", "fact"],
+        collocations: [
+          {
+            phrase: "basic concept",
+            definition: "a fundamental idea or principle",
+            example: "Students must understand the basic concepts before advancing."
+          },
+          {
+            phrase: "introduce concept",
+            definition: "to present or explain a new idea",
+            example: "The teacher will introduce the concept of democracy."
+          },
+          {
+            phrase: "abstract concept",
+            definition: "an idea that is not concrete or physical",
+            example: "Justice is an abstract concept that varies across cultures."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["academic", "philosophy", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "establish",
+        pronunciation: "/ɪˈstæblɪʃ/",
+        partOfSpeech: "verb",
+        definition: "to set up on a firm or permanent basis; to prove or demonstrate",
+        example: "The university was established in 1850.",
+        synonyms: ["found", "create", "set up", "prove"],
+        antonyms: ["destroy", "abolish", "disprove"],
+        collocations: [
+          {
+            phrase: "establish relationship",
+            definition: "to create or build connections",
+            example: "Countries work to establish diplomatic relationships."
+          },
+          {
+            phrase: "establish credibility",
+            definition: "to build trust and reliability",
+            example: "New businesses must establish credibility with customers."
+          },
+          {
+            phrase: "establish guidelines",
+            definition: "to create rules or principles",
+            example: "The committee will establish guidelines for research ethics."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["academic", "business", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "factor",
+        pronunciation: "/ˈfæktə/",
+        partOfSpeech: "noun",
+        definition: "a circumstance or element that contributes to a particular result",
+        example: "Climate is an important factor in agricultural productivity.",
+        synonyms: ["element", "component", "aspect", "influence"],
+        antonyms: [],
+        collocations: [
+          {
+            phrase: "key factor",
+            definition: "an important element or influence",
+            example: "Education is a key factor in economic development."
+          },
+          {
+            phrase: "contributing factor",
+            definition: "something that helps cause a result",
+            example: "Stress is a contributing factor to many health problems."
+          },
+          {
+            phrase: "external factor",
+            definition: "an outside influence or element",
+            example: "External factors like weather affect crop yields."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["academic", "analysis", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "indicate",
+        pronunciation: "/ˈɪndɪkeɪt/",
+        partOfSpeech: "verb",
+        definition: "to point out or show; to be a sign or symptom of",
+        example: "Research indicates that exercise improves mental health.",
+        synonyms: ["show", "suggest", "demonstrate", "reveal"],
+        antonyms: ["conceal", "hide"],
+        collocations: [
+          {
+            phrase: "clearly indicate",
+            definition: "to show something obviously",
+            example: "The data clearly indicates an upward trend."
+          },
+          {
+            phrase: "indicate that",
+            definition: "to show or suggest that something is true",
+            example: "Studies indicate that reading improves vocabulary."
+          },
+          {
+            phrase: "indicate direction",
+            definition: "to show which way to go",
+            example: "Road signs indicate the direction to the city center."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["academic", "research", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "method",
+        pronunciation: "/ˈmeθəd/",
+        partOfSpeech: "noun",
+        definition: "a particular form of procedure for accomplishing something",
+        example: "Scientists use various methods to conduct experiments.",
+        synonyms: ["technique", "approach", "way", "procedure"],
+        antonyms: ["chaos", "disorder"],
+        collocations: [
+          {
+            phrase: "effective method",
+            definition: "a successful way of doing something",
+            example: "Repetition is an effective method for learning vocabulary."
+          },
+          {
+            phrase: "teaching method",
+            definition: "a way of instructing students",
+            example: "Interactive teaching methods engage students more effectively."
+          },
+          {
+            phrase: "research method",
+            definition: "a systematic way of investigating",
+            example: "Qualitative research methods provide detailed insights."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["academic", "methodology", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "occur",
+        pronunciation: "/əˈkɜː/",
+        partOfSpeech: "verb",
+        definition: "to happen; to take place",
+        example: "Natural disasters occur more frequently due to climate change.",
+        synonyms: ["happen", "take place", "arise", "emerge"],
+        antonyms: ["cease", "stop"],
+        collocations: [
+          {
+            phrase: "frequently occur",
+            definition: "to happen often",
+            example: "Traffic jams frequently occur during rush hour."
+          },
+          {
+            phrase: "naturally occur",
+            definition: "to happen without human intervention",
+            example: "These minerals naturally occur in mountain regions."
+          },
+          {
+            phrase: "occur simultaneously",
+            definition: "to happen at the same time",
+            example: "Multiple events can occur simultaneously in complex systems."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["academic", "events", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "process",
+        pronunciation: "/ˈprəʊses/",
+        partOfSpeech: "noun/verb",
+        definition: "a series of actions or steps; to perform operations on data",
+        example: "The manufacturing process has been improved significantly.",
+        synonyms: ["procedure", "method", "system", "operation"],
+        antonyms: ["stagnation", "inactivity"],
+        collocations: [
+          {
+            phrase: "learning process",
+            definition: "the way knowledge is acquired",
+            example: "The learning process varies from person to person."
+          },
+          {
+            phrase: "decision-making process",
+            definition: "the steps involved in making choices",
+            example: "The decision-making process should involve all stakeholders."
+          },
+          {
+            phrase: "manufacturing process",
+            definition: "the steps in producing goods",
+            example: "Automation has revolutionized the manufacturing process."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["academic", "business", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "require",
+        pronunciation: "/rɪˈkwaɪə/",
+        partOfSpeech: "verb",
+        definition: "to need for a particular purpose; to demand as necessary",
+        example: "This job requires excellent communication skills.",
+        synonyms: ["need", "demand", "necessitate", "call for"],
+        antonyms: ["provide", "supply"],
+        collocations: [
+          {
+            phrase: "require attention",
+            definition: "to need focus or care",
+            example: "Environmental issues require immediate attention."
+          },
+          {
+            phrase: "require effort",
+            definition: "to need work or energy",
+            example: "Learning a language requires consistent effort."
+          },
+          {
+            phrase: "require approval",
+            definition: "to need official permission",
+            example: "New policies require approval from the board."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["academic", "requirements", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "structure",
+        pronunciation: "/ˈstrʌktʃə/",
+        partOfSpeech: "noun/verb",
+        definition: "the arrangement of parts in something; to organize or arrange",
+        example: "The essay has a clear structure with introduction, body, and conclusion.",
+        synonyms: ["organization", "framework", "arrangement", "system"],
+        antonyms: ["chaos", "disorder"],
+        collocations: [
+          {
+            phrase: "organizational structure",
+            definition: "the way a company or group is arranged",
+            example: "The company's organizational structure promotes efficiency."
+          },
+          {
+            phrase: "social structure",
+            definition: "the organization of society",
+            example: "Education can change social structure over time."
+          },
+          {
+            phrase: "sentence structure",
+            definition: "the way words are arranged in sentences",
+            example: "Good sentence structure improves writing clarity."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["academic", "organization", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+
+      // IELTS Band 6.5 - Advanced Collocations and Expressions
+      {
+        word: "take into account",
+        pronunciation: "/teɪk ˈɪntuː əˈkaʊnt/",
+        partOfSpeech: "phrase",
+        definition: "to consider something when making a decision or judgment",
+        example: "We must take into account the environmental impact of our actions.",
+        synonyms: ["consider", "factor in", "bear in mind"],
+        antonyms: ["ignore", "overlook"],
+        collocations: [
+          {
+            phrase: "take into account factors",
+            definition: "to consider various elements",
+            example: "Employers take into account many factors when hiring."
+          },
+          {
+            phrase: "fail to take into account",
+            definition: "to not consider important elements",
+            example: "The plan failed because it didn't take into account local conditions."
+          },
+          {
+            phrase: "must take into account",
+            definition: "it is necessary to consider",
+            example: "Policymakers must take into account public opinion."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["phrases", "decision-making", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "in terms of",
+        pronunciation: "/ɪn tɜːmz ɒv/",
+        partOfSpeech: "phrase",
+        definition: "with regard to; concerning",
+        example: "In terms of cost, this option is the most economical.",
+        synonyms: ["regarding", "concerning", "with respect to"],
+        antonyms: [],
+        collocations: [
+          {
+            phrase: "in terms of quality",
+            definition: "regarding the standard or grade",
+            example: "In terms of quality, this product exceeds expectations."
+          },
+          {
+            phrase: "in terms of time",
+            definition: "regarding duration or schedule",
+            example: "In terms of time, the project is ahead of schedule."
+          },
+          {
+            phrase: "in terms of benefits",
+            definition: "regarding advantages or positive aspects",
+            example: "In terms of benefits, renewable energy offers many advantages."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["phrases", "comparison", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "as a result of",
+        pronunciation: "/æz ə rɪˈzʌlt ɒv/",
+        partOfSpeech: "phrase",
+        definition: "because of; due to",
+        example: "As a result of the pandemic, many people started working from home.",
+        synonyms: ["due to", "because of", "owing to"],
+        antonyms: ["despite", "regardless of"],
+        collocations: [
+          {
+            phrase: "as a result of changes",
+            definition: "because of modifications or alterations",
+            example: "As a result of policy changes, unemployment decreased."
+          },
+          {
+            phrase: "as a result of research",
+            definition: "because of scientific investigation",
+            example: "As a result of medical research, new treatments were developed."
+          },
+          {
+            phrase: "as a result of efforts",
+            definition: "because of hard work or attempts",
+            example: "As a result of conservation efforts, the species was saved."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["phrases", "cause-effect", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      }
+    ];
+  }
+}

--- a/ielts-vocabulary-app/backend/src/vocabulary/vocabulary.controller.ts
+++ b/ielts-vocabulary-app/backend/src/vocabulary/vocabulary.controller.ts
@@ -1,11 +1,15 @@
 import { Controller, Get, Post, Body, Param, Query, UseGuards } from '@nestjs/common';
 import { VocabularyService } from './vocabulary.service';
+import { VocabularySeederService } from './vocabulary-seeder.service';
 import { CreateVocabularyDto } from './dto/create-vocabulary.dto';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
 
 @Controller('vocabulary')
 export class VocabularyController {
-  constructor(private readonly vocabularyService: VocabularyService) {}
+  constructor(
+    private readonly vocabularyService: VocabularyService,
+    private readonly vocabularySeederService: VocabularySeederService,
+  ) {}
 
   @Post()
   @UseGuards(JwtAuthGuard)
@@ -51,5 +55,12 @@ export class VocabularyController {
   @UseGuards(JwtAuthGuard)
   initializeSampleData() {
     return this.vocabularyService.initializeSampleData();
+  }
+
+  @Post('seed-ielts')
+  @UseGuards(JwtAuthGuard)
+  async seedIeltsVocabulary() {
+    await this.vocabularySeederService.seedIeltsVocabulary();
+    return { message: 'IELTS vocabulary seeded successfully' };
   }
 }

--- a/ielts-vocabulary-app/backend/src/vocabulary/vocabulary.module.ts
+++ b/ielts-vocabulary-app/backend/src/vocabulary/vocabulary.module.ts
@@ -1,10 +1,11 @@
 import { Module } from '@nestjs/common';
 import { VocabularyService } from './vocabulary.service';
 import { VocabularyController } from './vocabulary.controller';
+import { VocabularySeederService } from './vocabulary-seeder.service';
 
 @Module({
   controllers: [VocabularyController],
-  providers: [VocabularyService],
-  exports: [VocabularyService],
+  providers: [VocabularyService, VocabularySeederService],
+  exports: [VocabularyService, VocabularySeederService],
 })
 export class VocabularyModule {}

--- a/ielts-vocabulary-app/backend/src/vocabulary/vocabulary.service.ts
+++ b/ielts-vocabulary-app/backend/src/vocabulary/vocabulary.service.ts
@@ -14,6 +14,10 @@ export class VocabularyService {
     
     const vocabulary: Vocabulary = {
       ...createVocabularyDto,
+      synonyms: createVocabularyDto.synonyms || [],
+      antonyms: createVocabularyDto.antonyms || [],
+      collocations: createVocabularyDto.collocations || [],
+      topics: createVocabularyDto.topics || [],
       createdAt: now,
       updatedAt: now,
     };
@@ -41,7 +45,7 @@ export class VocabularyService {
     ]);
 
     return {
-      data,
+      data: data as Vocabulary[],
       total,
       page,
       totalPages: Math.ceil(total / limit),
@@ -50,14 +54,14 @@ export class VocabularyService {
 
   async findById(id: string): Promise<Vocabulary | null> {
     const db = this.databaseService.getDb();
-    return await db.collection('vocabulary').findOne({ _id: new ObjectId(id) });
+    return await db.collection('vocabulary').findOne({ _id: new ObjectId(id) }) as Vocabulary | null;
   }
 
   async findByWord(word: string): Promise<Vocabulary | null> {
     const db = this.databaseService.getDb();
     return await db.collection('vocabulary').findOne({ 
       word: { $regex: new RegExp(`^${word}$`, 'i') } 
-    });
+    }) as Vocabulary | null;
   }
 
   async search(query: string, page: number = 1, limit: number = 20): Promise<{
@@ -83,7 +87,7 @@ export class VocabularyService {
     ]);
 
     return {
-      data,
+      data: data as Vocabulary[],
       total,
       page,
       totalPages: Math.ceil(total / limit),
@@ -115,6 +119,7 @@ export class VocabularyService {
   private getSampleVocabulary(): Vocabulary[] {
     const now = new Date();
     return [
+      // Academic Word List - Essential for IELTS Band 6.5
       {
         word: "abundant",
         pronunciation: "/əˈbʌndənt/",
@@ -133,10 +138,15 @@ export class VocabularyService {
             phrase: "abundant evidence",
             definition: "plenty of proof or information",
             example: "There is abundant evidence to support this theory."
+          },
+          {
+            phrase: "abundant supply",
+            definition: "a large amount available",
+            example: "There is an abundant supply of fresh water in this region."
           }
         ],
         difficulty: "intermediate",
-        topics: ["environment", "economics"],
+        topics: ["environment", "economics", "ielts-writing"],
         createdAt: now,
         updatedAt: now,
       },
@@ -158,10 +168,15 @@ export class VocabularyService {
             phrase: "accommodate needs",
             definition: "to meet or satisfy requirements",
             example: "We will try to accommodate your special dietary needs."
+          },
+          {
+            phrase: "accommodate changes",
+            definition: "to adapt to modifications",
+            example: "The system can accommodate changes in user requirements."
           }
         ],
         difficulty: "intermediate",
-        topics: ["hospitality", "business"],
+        topics: ["hospitality", "business", "ielts-speaking"],
         createdAt: now,
         updatedAt: now,
       },
@@ -183,10 +198,15 @@ export class VocabularyService {
             phrase: "acquire skills",
             definition: "to develop abilities or expertise",
             example: "It takes time to acquire advanced programming skills."
+          },
+          {
+            phrase: "acquire experience",
+            definition: "to gain practical knowledge",
+            example: "Young professionals need to acquire experience in their field."
           }
         ],
         difficulty: "intermediate",
-        topics: ["education", "business"],
+        topics: ["education", "business", "ielts-writing"],
         createdAt: now,
         updatedAt: now,
       },
@@ -208,10 +228,15 @@ export class VocabularyService {
             phrase: "strong advocate",
             definition: "a passionate supporter of a cause",
             example: "She is a strong advocate for women's rights."
+          },
+          {
+            phrase: "advocate policies",
+            definition: "to support specific courses of action",
+            example: "The organization advocates policies that protect the environment."
           }
         ],
         difficulty: "advanced",
-        topics: ["politics", "social issues"],
+        topics: ["politics", "social issues", "ielts-writing"],
         createdAt: now,
         updatedAt: now,
       },
@@ -233,10 +258,442 @@ export class VocabularyService {
             phrase: "analyze results",
             definition: "to study outcomes or findings",
             example: "We need to analyze the results of the experiment."
+          },
+          {
+            phrase: "analyze trends",
+            definition: "to examine patterns over time",
+            example: "Economists analyze trends in the housing market."
           }
         ],
         difficulty: "intermediate",
-        topics: ["science", "research", "academic"],
+        topics: ["science", "research", "academic", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      // Environment & Climate Change - Common IELTS Topic
+      {
+        word: "sustainable",
+        pronunciation: "/səˈsteɪnəbəl/",
+        partOfSpeech: "adjective",
+        definition: "able to be maintained at a certain rate or level; environmentally responsible",
+        example: "We need to develop sustainable energy sources.",
+        synonyms: ["renewable", "viable", "maintainable", "eco-friendly"],
+        antonyms: ["unsustainable", "wasteful", "depleting"],
+        collocations: [
+          {
+            phrase: "sustainable development",
+            definition: "growth that meets present needs without compromising future generations",
+            example: "The UN promotes sustainable development goals worldwide."
+          },
+          {
+            phrase: "sustainable energy",
+            definition: "renewable energy sources that don't deplete natural resources",
+            example: "Solar and wind power are examples of sustainable energy."
+          },
+          {
+            phrase: "sustainable practices",
+            definition: "methods that can be continued long-term without harm",
+            example: "Companies are adopting sustainable practices to reduce their carbon footprint."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["environment", "climate change", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "emissions",
+        pronunciation: "/ɪˈmɪʃənz/",
+        partOfSpeech: "noun",
+        definition: "the production and discharge of something, especially gas or radiation",
+        example: "Carbon emissions from vehicles contribute to air pollution.",
+        synonyms: ["discharge", "release", "output", "pollution"],
+        antonyms: ["absorption", "intake"],
+        collocations: [
+          {
+            phrase: "carbon emissions",
+            definition: "carbon dioxide released into the atmosphere",
+            example: "Reducing carbon emissions is crucial for fighting climate change."
+          },
+          {
+            phrase: "greenhouse gas emissions",
+            definition: "gases that trap heat in the atmosphere",
+            example: "Countries are working to cut greenhouse gas emissions by 50%."
+          },
+          {
+            phrase: "reduce emissions",
+            definition: "to decrease the amount of pollutants released",
+            example: "Electric cars help reduce emissions in urban areas."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["environment", "climate change", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      // Technology - Common IELTS Topic
+      {
+        word: "innovation",
+        pronunciation: "/ˌɪnəˈveɪʃən/",
+        partOfSpeech: "noun",
+        definition: "the action or process of innovating; a new method, idea, or product",
+        example: "Technological innovation has transformed modern communication.",
+        synonyms: ["invention", "advancement", "breakthrough", "novelty"],
+        antonyms: ["tradition", "convention", "stagnation"],
+        collocations: [
+          {
+            phrase: "technological innovation",
+            definition: "new developments in technology",
+            example: "Technological innovation drives economic growth in many countries."
+          },
+          {
+            phrase: "foster innovation",
+            definition: "to encourage new ideas and creativity",
+            example: "Universities foster innovation through research programs."
+          },
+          {
+            phrase: "innovation hub",
+            definition: "a center where new ideas and technologies are developed",
+            example: "Silicon Valley is known as a global innovation hub."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["technology", "business", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "digital",
+        pronunciation: "/ˈdɪdʒɪtəl/",
+        partOfSpeech: "adjective",
+        definition: "relating to or using computer technology",
+        example: "The digital revolution has changed how we work and communicate.",
+        synonyms: ["electronic", "computerized", "online", "virtual"],
+        antonyms: ["analog", "physical", "traditional"],
+        collocations: [
+          {
+            phrase: "digital transformation",
+            definition: "the integration of digital technology into all areas of business",
+            example: "Many companies are undergoing digital transformation to stay competitive."
+          },
+          {
+            phrase: "digital divide",
+            definition: "the gap between those who have access to technology and those who don't",
+            example: "The digital divide affects educational opportunities in rural areas."
+          },
+          {
+            phrase: "digital literacy",
+            definition: "the ability to use digital technology effectively",
+            example: "Digital literacy is essential for success in the modern workplace."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["technology", "education", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      // Education - Common IELTS Topic
+      {
+        word: "curriculum",
+        pronunciation: "/kəˈrɪkjʊləm/",
+        partOfSpeech: "noun",
+        definition: "the subjects comprising a course of study in a school or college",
+        example: "The new curriculum includes more emphasis on critical thinking skills.",
+        synonyms: ["syllabus", "program", "course", "studies"],
+        antonyms: [],
+        collocations: [
+          {
+            phrase: "school curriculum",
+            definition: "the subjects taught in schools",
+            example: "The school curriculum should prepare students for future careers."
+          },
+          {
+            phrase: "design curriculum",
+            definition: "to plan and organize educational content",
+            example: "Educators work together to design curriculum that meets student needs."
+          },
+          {
+            phrase: "curriculum development",
+            definition: "the process of creating educational programs",
+            example: "Curriculum development requires input from teachers, parents, and experts."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["education", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "literacy",
+        pronunciation: "/ˈlɪtərəsi/",
+        partOfSpeech: "noun",
+        definition: "the ability to read and write; competence in a particular area",
+        example: "Financial literacy is important for making good money decisions.",
+        synonyms: ["education", "learning", "knowledge", "competence"],
+        antonyms: ["illiteracy", "ignorance"],
+        collocations: [
+          {
+            phrase: "improve literacy",
+            definition: "to enhance reading and writing skills",
+            example: "The program aims to improve literacy rates in developing countries."
+          },
+          {
+            phrase: "literacy rate",
+            definition: "the percentage of people who can read and write",
+            example: "The country has achieved a 95% literacy rate among adults."
+          },
+          {
+            phrase: "digital literacy",
+            definition: "skills needed to use technology effectively",
+            example: "Digital literacy is becoming as important as traditional literacy."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["education", "social issues", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      // Health & Lifestyle - Common IELTS Topic
+      {
+        word: "obesity",
+        pronunciation: "/əʊˈbiːsəti/",
+        partOfSpeech: "noun",
+        definition: "the condition of being grossly fat or overweight",
+        example: "Childhood obesity has become a major public health concern.",
+        synonyms: ["overweight", "corpulence"],
+        antonyms: ["thinness", "underweight"],
+        collocations: [
+          {
+            phrase: "childhood obesity",
+            definition: "excessive weight in children",
+            example: "Childhood obesity rates have doubled in the past 30 years."
+          },
+          {
+            phrase: "combat obesity",
+            definition: "to fight against excessive weight problems",
+            example: "Schools are implementing programs to combat obesity among students."
+          },
+          {
+            phrase: "obesity epidemic",
+            definition: "widespread occurrence of obesity in a population",
+            example: "Many countries are facing an obesity epidemic due to lifestyle changes."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["health", "lifestyle", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "sedentary",
+        pronunciation: "/ˈsedəntəri/",
+        partOfSpeech: "adjective",
+        definition: "requiring much sitting and little physical exercise",
+        example: "A sedentary lifestyle can lead to various health problems.",
+        synonyms: ["inactive", "stationary", "immobile"],
+        antonyms: ["active", "mobile", "energetic"],
+        collocations: [
+          {
+            phrase: "sedentary lifestyle",
+            definition: "a way of living with little physical activity",
+            example: "Modern office workers often have a sedentary lifestyle."
+          },
+          {
+            phrase: "sedentary behavior",
+            definition: "activities involving sitting or lying down",
+            example: "Excessive sedentary behavior is linked to heart disease."
+          },
+          {
+            phrase: "sedentary work",
+            definition: "jobs that require sitting for long periods",
+            example: "People with sedentary work should take regular breaks to exercise."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["health", "lifestyle", "work", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      // Urbanization & Housing - Common IELTS Topic
+      {
+        word: "urbanization",
+        pronunciation: "/ˌɜːbənaɪˈzeɪʃən/",
+        partOfSpeech: "noun",
+        definition: "the process by which towns and cities are formed and become larger",
+        example: "Rapid urbanization has created both opportunities and challenges.",
+        synonyms: ["urban development", "city growth"],
+        antonyms: ["ruralization"],
+        collocations: [
+          {
+            phrase: "rapid urbanization",
+            definition: "fast growth of cities and towns",
+            example: "Rapid urbanization in developing countries strains infrastructure."
+          },
+          {
+            phrase: "urbanization process",
+            definition: "the way cities develop and expand",
+            example: "The urbanization process affects both social and economic structures."
+          },
+          {
+            phrase: "effects of urbanization",
+            definition: "consequences of city growth",
+            example: "The effects of urbanization include both benefits and problems."
+          }
+        ],
+        difficulty: "advanced",
+        topics: ["cities", "development", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "infrastructure",
+        pronunciation: "/ˈɪnfrəstrʌktʃə/",
+        partOfSpeech: "noun",
+        definition: "the basic physical and organizational structures needed for operation",
+        example: "Good infrastructure is essential for economic development.",
+        synonyms: ["framework", "foundation", "structure"],
+        antonyms: [],
+        collocations: [
+          {
+            phrase: "transport infrastructure",
+            definition: "roads, railways, and other transportation systems",
+            example: "Investment in transport infrastructure improves connectivity."
+          },
+          {
+            phrase: "develop infrastructure",
+            definition: "to build and improve basic facilities",
+            example: "The government plans to develop infrastructure in rural areas."
+          },
+          {
+            phrase: "infrastructure investment",
+            definition: "money spent on building basic facilities",
+            example: "Infrastructure investment creates jobs and boosts the economy."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["cities", "development", "economics", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      // Work & Employment - Common IELTS Topic
+      {
+        word: "unemployment",
+        pronunciation: "/ˌʌnɪmˈplɔɪmənt/",
+        partOfSpeech: "noun",
+        definition: "the state of being jobless; the number of unemployed people",
+        example: "High unemployment rates affect the entire economy.",
+        synonyms: ["joblessness", "worklessness"],
+        antonyms: ["employment", "work"],
+        collocations: [
+          {
+            phrase: "unemployment rate",
+            definition: "the percentage of people without jobs",
+            example: "The unemployment rate fell to 5% last month."
+          },
+          {
+            phrase: "reduce unemployment",
+            definition: "to decrease the number of jobless people",
+            example: "The government introduced policies to reduce unemployment."
+          },
+          {
+            phrase: "youth unemployment",
+            definition: "joblessness among young people",
+            example: "Youth unemployment is a serious problem in many countries."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["work", "economics", "social issues", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      // Essential Phrasal Verbs for IELTS Band 6.5
+      {
+        word: "bring about",
+        pronunciation: "/brɪŋ əˈbaʊt/",
+        partOfSpeech: "phrasal verb",
+        definition: "to cause something to happen",
+        example: "The new policies will bring about significant changes in education.",
+        synonyms: ["cause", "create", "produce", "generate"],
+        antonyms: ["prevent", "stop"],
+        collocations: [
+          {
+            phrase: "bring about change",
+            definition: "to cause transformation or reform",
+            example: "Technology can bring about positive change in healthcare."
+          },
+          {
+            phrase: "bring about improvement",
+            definition: "to cause something to become better",
+            example: "The new management brought about improvement in company performance."
+          },
+          {
+            phrase: "bring about reform",
+            definition: "to cause systematic change",
+            example: "Public pressure can bring about reform in government policies."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["phrasal verbs", "ielts-writing", "ielts-speaking"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "carry out",
+        pronunciation: "/ˈkæri aʊt/",
+        partOfSpeech: "phrasal verb",
+        definition: "to perform or complete a task, duty, or plan",
+        example: "Scientists carry out experiments to test their theories.",
+        synonyms: ["perform", "execute", "conduct", "implement"],
+        antonyms: ["abandon", "cancel"],
+        collocations: [
+          {
+            phrase: "carry out research",
+            definition: "to conduct scientific investigation",
+            example: "Universities carry out research in various fields of study."
+          },
+          {
+            phrase: "carry out a survey",
+            definition: "to conduct a study or poll",
+            example: "The company will carry out a survey to understand customer needs."
+          },
+          {
+            phrase: "carry out plans",
+            definition: "to implement or execute strategies",
+            example: "The team successfully carried out their marketing plans."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["phrasal verbs", "academic", "ielts-writing"],
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        word: "cope with",
+        pronunciation: "/kəʊp wɪð/",
+        partOfSpeech: "phrasal verb",
+        definition: "to deal effectively with something difficult",
+        example: "Students need strategies to cope with exam stress.",
+        synonyms: ["handle", "manage", "deal with", "tackle"],
+        antonyms: ["surrender", "give up"],
+        collocations: [
+          {
+            phrase: "cope with stress",
+            definition: "to manage pressure and anxiety",
+            example: "Exercise helps people cope with stress more effectively."
+          },
+          {
+            phrase: "cope with change",
+            definition: "to adapt to new situations",
+            example: "Employees need training to cope with technological change."
+          },
+          {
+            phrase: "cope with challenges",
+            definition: "to handle difficult situations",
+            example: "Strong leadership helps organizations cope with challenges."
+          }
+        ],
+        difficulty: "intermediate",
+        topics: ["phrasal verbs", "psychology", "ielts-speaking"],
         createdAt: now,
         updatedAt: now,
       }

--- a/ielts-vocabulary-app/frontend/package-lock.json
+++ b/ielts-vocabulary-app/frontend/package-lock.json
@@ -30,6 +30,7 @@
         "react-router-dom": "^7.9.3",
         "react-scripts": "5.0.1",
         "tailwind-merge": "^3.3.1",
+        "tailwindcss": "^3.4.18",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -37,8 +38,7 @@
       "devDependencies": {
         "@types/react-router-dom": "^5.3.3",
         "autoprefixer": "^10.4.21",
-        "postcss": "^8.5.6",
-        "tailwindcss": "^4.1.14"
+        "postcss": "^8.5.6"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -14904,111 +14904,6 @@
         }
       }
     },
-    "node_modules/react-scripts/node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
-    },
-    "node_modules/react-scripts/node_modules/postcss-load-config": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "lilconfig": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "jiti": ">=1.21.0",
-        "postcss": ">=8.0.9",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-scripts/node_modules/tailwindcss": {
-      "version": "3.4.18",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
-      "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.21.7",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/react-scripts/node_modules/yaml": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      }
-    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -16901,10 +16796,41 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.14.tgz",
-      "integrity": "sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==",
-      "license": "MIT"
+      "version": "3.4.18",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.18.tgz",
+      "integrity": "sha512-6A2rnmW5xZMdw11LYjhcI5846rt9pbLSabY5XPxo+XWdxwZaFEn47Go4NzFiHu9sNNmr/kXivP1vStfvMaK1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -16913,6 +16839,74 @@
       "license": "MIT",
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tailwindcss/node_modules/yaml": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
+      "integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
       }
     },
     "node_modules/tapable": {

--- a/ielts-vocabulary-app/frontend/package.json
+++ b/ielts-vocabulary-app/frontend/package.json
@@ -25,6 +25,7 @@
     "react-router-dom": "^7.9.3",
     "react-scripts": "5.0.1",
     "tailwind-merge": "^3.3.1",
+    "tailwindcss": "^3.4.18",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
@@ -56,7 +57,6 @@
   "devDependencies": {
     "@types/react-router-dom": "^5.3.3",
     "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.6",
-    "tailwindcss": "^4.1.14"
+    "postcss": "^8.5.6"
   }
 }

--- a/ielts-vocabulary-app/frontend/src/App.tsx
+++ b/ielts-vocabulary-app/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import HomePage from './pages/HomePage';
 import AuthCallbackPage from './pages/AuthCallbackPage';
 import DashboardPage from './pages/DashboardPage';
 import StudyPage from './pages/StudyPage';
+import IeltsVocabularyPage from './pages/IeltsVocabularyPage';
 
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { isAuthenticated } = useAuth();
@@ -32,6 +33,14 @@ function App() {
               element={
                 <ProtectedRoute>
                   <StudyPage />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/ielts-vocabulary"
+              element={
+                <ProtectedRoute>
+                  <IeltsVocabularyPage />
                 </ProtectedRoute>
               }
             />

--- a/ielts-vocabulary-app/frontend/src/components/ui/button.tsx
+++ b/ielts-vocabulary-app/frontend/src/components/ui/button.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",

--- a/ielts-vocabulary-app/frontend/src/components/ui/card.tsx
+++ b/ielts-vocabulary-app/frontend/src/components/ui/card.tsx
@@ -1,6 +1,6 @@
 import * as React from "react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Card = React.forwardRef<
   HTMLDivElement,

--- a/ielts-vocabulary-app/frontend/src/components/ui/progress.tsx
+++ b/ielts-vocabulary-app/frontend/src/components/ui/progress.tsx
@@ -1,7 +1,7 @@
 import * as React from "react"
 import * as ProgressPrimitive from "@radix-ui/react-progress"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const Progress = React.forwardRef<
   React.ElementRef<typeof ProgressPrimitive.Root>,

--- a/ielts-vocabulary-app/frontend/src/pages/DashboardPage.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/DashboardPage.tsx
@@ -6,7 +6,7 @@ import { Progress } from '../components/ui/progress';
 import { useAuth } from '../hooks/useAuth';
 import { userAPI, vocabularyAPI } from '../services/api';
 import { UserProgress, StudySession } from '../types';
-import { BookOpen, Brain, Target, TrendingUp, LogOut, Play } from 'lucide-react';
+import { BookOpen, Brain, Target, TrendingUp, LogOut, Play, Library } from 'lucide-react';
 
 const DashboardPage: React.FC = () => {
   const { user, logout } = useAuth();
@@ -168,7 +168,7 @@ const DashboardPage: React.FC = () => {
         </div>
 
         {/* Study Section */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
           <Card>
             <CardHeader>
               <CardTitle className="flex items-center">
@@ -189,6 +189,26 @@ const DashboardPage: React.FC = () => {
                 disabled={stats.dueToday === 0}
               >
                 {stats.dueToday > 0 ? 'Ôn tập ngay' : 'Học từ mới'}
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center">
+                <Library className="h-5 w-5 mr-2 text-purple-600" />
+                Gói từ vựng IELTS
+              </CardTitle>
+              <CardDescription>
+                Khám phá từ vựng theo chủ đề và cấp độ
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Button 
+                onClick={() => navigate('/ielts-vocabulary')} 
+                className="w-full bg-purple-600 hover:bg-purple-700"
+              >
+                Xem gói từ vựng
               </Button>
             </CardContent>
           </Card>

--- a/ielts-vocabulary-app/frontend/src/pages/IeltsVocabularyPage.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/IeltsVocabularyPage.tsx
@@ -1,0 +1,368 @@
+import React, { useState, useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
+import { Button } from '../components/ui/button';
+import { vocabularyAPI } from '../services/api';
+import { Vocabulary } from '../types';
+import { BookOpen, Target, Users, Lightbulb, Volume2, Star } from 'lucide-react';
+
+const IeltsVocabularyPage: React.FC = () => {
+  const [vocabularyData, setVocabularyData] = useState<{
+    data: Vocabulary[];
+    total: number;
+    page: number;
+    totalPages: number;
+  } | null>(null);
+  const [selectedTopic, setSelectedTopic] = useState<string>('all');
+  const [selectedDifficulty, setSelectedDifficulty] = useState<string>('all');
+  const [loading, setLoading] = useState(true);
+  const [seeding, setSeeding] = useState(false);
+  const [topics, setTopics] = useState<string[]>([]);
+
+  const ieltsTopics = [
+    { key: 'ielts-writing', label: 'IELTS Writing', icon: '✍️', description: 'Essential vocabulary for Task 1 & 2' },
+    { key: 'ielts-speaking', label: 'IELTS Speaking', icon: '🗣️', description: 'Key phrases for all speaking parts' },
+    { key: 'environment', label: 'Environment', icon: '🌱', description: 'Climate change, sustainability' },
+    { key: 'technology', label: 'Technology', icon: '💻', description: 'Digital age, AI, innovation' },
+    { key: 'education', label: 'Education', icon: '🎓', description: 'Learning, curriculum, pedagogy' },
+    { key: 'health', label: 'Health', icon: '🏥', description: 'Lifestyle, mental health, wellness' },
+    { key: 'business', label: 'Business', icon: '💼', description: 'Economics, entrepreneurship' },
+    { key: 'phrasal verbs', label: 'Phrasal Verbs', icon: '🔗', description: 'Essential phrasal verbs for Band 6.5' },
+  ];
+
+  const difficultyLevels = [
+    { key: 'beginner', label: 'Beginner', color: 'bg-green-100 text-green-800', description: 'Foundation level' },
+    { key: 'intermediate', label: 'Intermediate', color: 'bg-blue-100 text-blue-800', description: 'Band 5.5-6.5' },
+    { key: 'advanced', label: 'Advanced', color: 'bg-purple-100 text-purple-800', description: 'Band 7.0+' },
+  ];
+
+  useEffect(() => {
+    loadVocabulary();
+    loadTopics();
+  }, [selectedTopic, selectedDifficulty]);
+
+  const loadVocabulary = async () => {
+    try {
+      setLoading(true);
+      const params: any = { limit: 50 };
+      if (selectedTopic !== 'all') params.topic = selectedTopic;
+      if (selectedDifficulty !== 'all') params.difficulty = selectedDifficulty;
+      
+      const data = await vocabularyAPI.getAll(params);
+      setVocabularyData(data);
+    } catch (error) {
+      console.error('Error loading vocabulary:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadTopics = async () => {
+    try {
+      const topicList = await vocabularyAPI.getTopics();
+      setTopics(topicList);
+    } catch (error) {
+      console.error('Error loading topics:', error);
+    }
+  };
+
+  const handleSeedIeltsVocabulary = async () => {
+    try {
+      setSeeding(true);
+      await vocabularyAPI.seedIeltsVocabulary();
+      alert('IELTS vocabulary đã được thêm thành công!');
+      loadVocabulary();
+      loadTopics();
+    } catch (error) {
+      console.error('Error seeding vocabulary:', error);
+      alert('Có lỗi xảy ra khi thêm từ vựng IELTS');
+    } finally {
+      setSeeding(false);
+    }
+  };
+
+  const speakWord = (text: string) => {
+    if ('speechSynthesis' in window) {
+      const utterance = new SpeechSynthesisUtterance(text);
+      utterance.lang = 'en-US';
+      speechSynthesis.speak(utterance);
+    }
+  };
+
+  const getTopicInfo = (topicKey: string) => {
+    return ieltsTopics.find(t => t.key === topicKey) || { 
+      key: topicKey, 
+      label: topicKey, 
+      icon: '📚', 
+      description: 'General vocabulary' 
+    };
+  };
+
+  const getDifficultyInfo = (difficulty: string) => {
+    return difficultyLevels.find(d => d.key === difficulty) || difficultyLevels[1];
+  };
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-4">
+      <div className="max-w-7xl mx-auto">
+        {/* Header */}
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900 mb-2">
+                📚 Gói từ vựng IELTS Band 6.5
+              </h1>
+              <p className="text-gray-600">
+                Bộ sưu tập từ vựng chuyên biệt cho kỳ thi IELTS, được phân loại theo chủ đề và độ khó
+              </p>
+            </div>
+            <Button 
+              onClick={handleSeedIeltsVocabulary} 
+              disabled={seeding}
+              className="bg-blue-600 hover:bg-blue-700"
+            >
+              {seeding ? 'Đang thêm...' : '+ Thêm từ vựng IELTS'}
+            </Button>
+          </div>
+
+          {/* Statistics */}
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-6">
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center">
+                  <BookOpen className="h-8 w-8 text-blue-600 mr-3" />
+                  <div>
+                    <p className="text-2xl font-bold">{vocabularyData?.total || 0}</p>
+                    <p className="text-sm text-gray-600">Tổng từ vựng</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center">
+                  <Target className="h-8 w-8 text-green-600 mr-3" />
+                  <div>
+                    <p className="text-2xl font-bold">6.5</p>
+                    <p className="text-sm text-gray-600">Mục tiêu Band</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center">
+                  <Users className="h-8 w-8 text-purple-600 mr-3" />
+                  <div>
+                    <p className="text-2xl font-bold">{topics.length}</p>
+                    <p className="text-sm text-gray-600">Chủ đề</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+            <Card>
+              <CardContent className="p-4">
+                <div className="flex items-center">
+                  <Lightbulb className="h-8 w-8 text-yellow-600 mr-3" />
+                  <div>
+                    <p className="text-2xl font-bold">3</p>
+                    <p className="text-sm text-gray-600">Cấp độ</p>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        {/* Filters */}
+        <div className="mb-6">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {/* Topic Filter */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Chọn chủ đề IELTS</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="grid grid-cols-2 gap-3">
+                  <button
+                    onClick={() => setSelectedTopic('all')}
+                    className={`p-3 rounded-lg border text-left transition-colors ${
+                      selectedTopic === 'all' 
+                        ? 'border-blue-500 bg-blue-50 text-blue-700' 
+                        : 'border-gray-200 hover:border-gray-300'
+                    }`}
+                  >
+                    <div className="font-medium">📚 Tất cả</div>
+                    <div className="text-sm text-gray-600">Toàn bộ từ vựng</div>
+                  </button>
+                  {ieltsTopics.map((topic) => (
+                    <button
+                      key={topic.key}
+                      onClick={() => setSelectedTopic(topic.key)}
+                      className={`p-3 rounded-lg border text-left transition-colors ${
+                        selectedTopic === topic.key 
+                          ? 'border-blue-500 bg-blue-50 text-blue-700' 
+                          : 'border-gray-200 hover:border-gray-300'
+                      }`}
+                    >
+                      <div className="font-medium">{topic.icon} {topic.label}</div>
+                      <div className="text-sm text-gray-600">{topic.description}</div>
+                    </button>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Difficulty Filter */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">Chọn cấp độ</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  <button
+                    onClick={() => setSelectedDifficulty('all')}
+                    className={`w-full p-3 rounded-lg border text-left transition-colors ${
+                      selectedDifficulty === 'all' 
+                        ? 'border-blue-500 bg-blue-50 text-blue-700' 
+                        : 'border-gray-200 hover:border-gray-300'
+                    }`}
+                  >
+                    <div className="font-medium">🎯 Tất cả cấp độ</div>
+                    <div className="text-sm text-gray-600">Từ cơ bản đến nâng cao</div>
+                  </button>
+                  {difficultyLevels.map((level) => (
+                    <button
+                      key={level.key}
+                      onClick={() => setSelectedDifficulty(level.key)}
+                      className={`w-full p-3 rounded-lg border text-left transition-colors ${
+                        selectedDifficulty === level.key 
+                          ? 'border-blue-500 bg-blue-50 text-blue-700' 
+                          : 'border-gray-200 hover:border-gray-300'
+                      }`}
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="font-medium">{level.label}</div>
+                        <span className={`px-2 py-1 rounded text-xs ${level.color}`}>
+                          {level.description}
+                        </span>
+                      </div>
+                    </button>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+
+        {/* Vocabulary List */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <span>
+                Từ vựng {selectedTopic !== 'all' && `- ${getTopicInfo(selectedTopic).label}`}
+                {selectedDifficulty !== 'all' && ` (${getDifficultyInfo(selectedDifficulty).label})`}
+              </span>
+              <span className="text-sm font-normal text-gray-600">
+                {vocabularyData?.total || 0} từ
+              </span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <div className="text-center py-8">
+                <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600 mx-auto"></div>
+                <p className="mt-4 text-gray-600">Đang tải từ vựng...</p>
+              </div>
+            ) : vocabularyData?.data.length === 0 ? (
+              <div className="text-center py-8">
+                <BookOpen className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+                <p className="text-gray-600">Không tìm thấy từ vựng phù hợp</p>
+                <p className="text-sm text-gray-500 mt-2">
+                  Thử thay đổi bộ lọc hoặc thêm từ vựng IELTS mới
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {vocabularyData?.data.map((vocab) => (
+                  <Card key={vocab._id} className="hover:shadow-md transition-shadow">
+                    <CardContent className="p-4">
+                      <div className="flex items-start justify-between mb-3">
+                        <div className="flex-1">
+                          <div className="flex items-center gap-2 mb-1">
+                            <h3 className="text-lg font-bold text-blue-600">
+                              {vocab.word}
+                            </h3>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => speakWord(vocab.word)}
+                              className="p-1 h-6 w-6"
+                            >
+                              <Volume2 className="h-3 w-3" />
+                            </Button>
+                          </div>
+                          <p className="text-sm text-gray-600 mb-1">
+                            {vocab.pronunciation}
+                          </p>
+                          <span className="text-xs bg-gray-100 text-gray-700 px-2 py-1 rounded">
+                            {vocab.partOfSpeech}
+                          </span>
+                        </div>
+                        <span className={`px-2 py-1 rounded text-xs ${getDifficultyInfo(vocab.difficulty).color}`}>
+                          {getDifficultyInfo(vocab.difficulty).label}
+                        </span>
+                      </div>
+
+                      <p className="text-sm text-gray-700 mb-3">
+                        {vocab.definition}
+                      </p>
+
+                      <div className="bg-gray-50 p-2 rounded mb-3">
+                        <p className="text-sm italic text-gray-600">
+                          "{vocab.example}"
+                        </p>
+                      </div>
+
+                      {vocab.collocations.length > 0 && (
+                        <div className="mb-3">
+                          <h4 className="text-xs font-semibold text-gray-700 mb-2">
+                            Collocations:
+                          </h4>
+                          <div className="space-y-1">
+                            {vocab.collocations.slice(0, 2).map((collocation, index) => (
+                              <div key={index} className="text-xs">
+                                <span className="font-medium text-blue-600">
+                                  {collocation.phrase}
+                                </span>
+                                <p className="text-gray-600 ml-2">
+                                  {collocation.definition}
+                                </p>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+
+                      <div className="flex flex-wrap gap-1">
+                        {vocab.topics.slice(0, 3).map((topic) => (
+                          <span
+                            key={topic}
+                            className="text-xs bg-blue-100 text-blue-700 px-2 py-1 rounded"
+                          >
+                            {getTopicInfo(topic).icon} {topic}
+                          </span>
+                        ))}
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default IeltsVocabularyPage;

--- a/ielts-vocabulary-app/frontend/src/services/api.ts
+++ b/ielts-vocabulary-app/frontend/src/services/api.ts
@@ -68,6 +68,11 @@ export const vocabularyAPI = {
     const response = await api.post('/vocabulary/initialize');
     return response.data;
   },
+
+  seedIeltsVocabulary: async () => {
+    const response = await api.post('/vocabulary/seed-ielts');
+    return response.data;
+  },
 };
 
 export const userAPI = {

--- a/ielts-vocabulary-app/frontend/tailwind.config.js
+++ b/ielts-vocabulary-app/frontend/tailwind.config.js
@@ -1,21 +1,10 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  darkMode: ["class"],
   content: [
-    './pages/**/*.{ts,tsx}',
-    './components/**/*.{ts,tsx}',
-    './app/**/*.{ts,tsx}',
-    './src/**/*.{ts,tsx}',
+    './src/**/*.{js,jsx,ts,tsx}',
+    './public/index.html',
   ],
-  prefix: "",
   theme: {
-    container: {
-      center: true,
-      padding: "2rem",
-      screens: {
-        "2xl": "1400px",
-      },
-    },
     extend: {
       colors: {
         border: "hsl(var(--border))",
@@ -57,21 +46,7 @@ module.exports = {
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
       },
-      keyframes: {
-        "accordion-down": {
-          from: { height: "0" },
-          to: { height: "var(--radix-accordion-content-height)" },
-        },
-        "accordion-up": {
-          from: { height: "var(--radix-accordion-content-height)" },
-          to: { height: "0" },
-        },
-      },
-      animation: {
-        "accordion-down": "accordion-down 0.2s ease-out",
-        "accordion-up": "accordion-up 0.2s ease-out",
-      },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [],
 }


### PR DESCRIPTION
Add IELTS Band 6.5 vocabulary packages and a dedicated frontend page for browsing them.

This PR introduces a new backend service to seed over 80 IELTS-focused vocabulary words, including Academic Word List, topic-specific terms (Environment, Technology, Education, Health, Business), essential phrasal verbs, and collocations, all tailored for Band 6.5. A new frontend page (`/ielts-vocabulary`) allows users to browse these packages with filters for topic and difficulty, and includes an option to trigger the vocabulary seeding. A link to this page has been added to the dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-85462e27-804d-4180-a2ad-1ef86f72a276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-85462e27-804d-4180-a2ad-1ef86f72a276"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

