### PR TITLE
Add vocabulary media assets with audio playback and illustrations

### DIFF
--- a/ielts-vocabulary-app/backend/src/vocabulary/dto/create-vocabulary.dto.ts
+++ b/ielts-vocabulary-app/backend/src/vocabulary/dto/create-vocabulary.dto.ts
@@ -35,4 +35,12 @@ export class CreateVocabularyDto {
   @IsArray()
   @IsOptional()
   topics?: string[];
+
+  @IsString()
+  @IsOptional()
+  imageUrl?: string;
+
+  @IsString()
+  @IsOptional()
+  audioUrl?: string;
 }

--- a/ielts-vocabulary-app/backend/src/vocabulary/interfaces/vocabulary.interface.ts
+++ b/ielts-vocabulary-app/backend/src/vocabulary/interfaces/vocabulary.interface.ts
@@ -12,6 +12,8 @@ export interface Vocabulary {
   collocations?: Collocation[];
   difficulty: 'beginner' | 'intermediate' | 'advanced';
   topics?: string[];
+  imageUrl?: string;
+  audioUrl?: string;
   createdAt?: Date;
   updatedAt?: Date;
 }

--- a/ielts-vocabulary-app/frontend/src/lib/media.ts
+++ b/ielts-vocabulary-app/frontend/src/lib/media.ts
@@ -1,0 +1,49 @@
+import { Vocabulary } from '../types';
+
+export const FALLBACK_VOCABULARY_IMAGE =
+  'https://images.unsplash.com/photo-1529070538774-1843cb3265df?auto=format&fit=crop&w=800&q=60';
+
+const slugifyForAudio = (word: string): string => {
+  const normalized = word
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+
+  return normalized
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    || normalized
+    || word.toLowerCase();
+};
+
+export const buildVocabularyAudioUrl = (word: string): string => {
+  const slug = slugifyForAudio(word);
+  return `https://api.dictionaryapi.dev/media/pronunciations/en/${slug}-us.mp3`;
+};
+
+export const buildVocabularyImageUrl = (vocabulary: Vocabulary): string => {
+  const provided = vocabulary.imageUrl?.trim();
+  if (provided) {
+    return provided;
+  }
+
+  const keywordParts = [vocabulary.word, ...vocabulary.topics, vocabulary.difficulty]
+    .filter(Boolean)
+    .join(' ');
+
+  const query = encodeURIComponent(keywordParts || vocabulary.word);
+  return `https://source.unsplash.com/featured/400x300?${query}`;
+};
+
+export const resolveVocabularyImageUrl = (vocabulary: Vocabulary): string => {
+  return buildVocabularyImageUrl(vocabulary) || FALLBACK_VOCABULARY_IMAGE;
+};
+
+export const resolveVocabularyAudioUrl = (vocabulary: Vocabulary): string => {
+  const provided = vocabulary.audioUrl?.trim();
+  if (provided) {
+    return provided;
+  }
+
+  return buildVocabularyAudioUrl(vocabulary.word);
+};

--- a/ielts-vocabulary-app/frontend/src/types/index.ts
+++ b/ielts-vocabulary-app/frontend/src/types/index.ts
@@ -17,6 +17,8 @@ export interface Vocabulary {
   collocations: Collocation[];
   difficulty: 'beginner' | 'intermediate' | 'advanced';
   topics: string[];
+  imageUrl?: string;
+  audioUrl?: string;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary
- extend the vocabulary schema and service to include optional image and audio URLs with automatic fallbacks
- add shared media utilities and enrich the IELTS vocabulary page with illustrations plus cached audio playback controls
- enhance the study session view with the new media helpers so each word shows an illustration and reliable pronunciation button

## Testing
- npm run build (backend)
- npm run build (frontend)

------
https://chatgpt.com/codex/tasks/task_e_68de36c053bc8328a6471a18c4ae439e