### PR TITLE
Add dashboard study insights and mastery overview

### DIFF
--- a/ielts-vocabulary-app/frontend/src/pages/home/LearningDashboard.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/LearningDashboard.tsx
@@ -3,6 +3,8 @@ import { User } from '../../types';
 import DashboardHeader from './components/DashboardHeader';
 import LearningSummary from './components/LearningSummary';
 import UpcomingReviews from './components/UpcomingReviews';
+import MasteryOverview from './components/MasteryOverview';
+import StudyPlanCard from './components/StudyPlanCard';
 import useDashboardData from './useDashboardData';
 
 interface LearningDashboardProps {
@@ -18,13 +20,17 @@ const LearningDashboard: React.FC<LearningDashboardProps> = ({
   onExploreVocabulary,
   onLogout,
 }) => {
-  const { stats, dueVocabulary, isLoading } = useDashboardData();
+  const { stats, dueVocabulary, levelDistribution, studyPlan, isLoading } = useDashboardData();
 
   return (
     <div className="min-h-screen bg-slate-50">
       <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-10">
         <DashboardHeader user={user} onStartStudy={onStartStudy} onLogout={onLogout} />
         <LearningSummary stats={stats} />
+        <section className="grid gap-4 md:grid-cols-2">
+          <StudyPlanCard plan={studyPlan} />
+          <MasteryOverview distribution={levelDistribution} />
+        </section>
         <UpcomingReviews
           dueVocabulary={dueVocabulary}
           onExploreVocabulary={onExploreVocabulary}

--- a/ielts-vocabulary-app/frontend/src/pages/home/components/MasteryOverview.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/components/MasteryOverview.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Progress } from '../../../components/ui/progress';
+import { LevelSegment } from '../insights';
+
+interface MasteryOverviewProps {
+  distribution: LevelSegment[];
+}
+
+const MasteryOverview: React.FC<MasteryOverviewProps> = ({ distribution }) => {
+  const total = distribution.reduce((sum, item) => sum + item.count, 0) || 1;
+
+  return (
+    <section className="rounded-3xl bg-white p-6 shadow-sm">
+      <h2 className="text-xl font-semibold text-slate-900">Mức độ thuần thục</h2>
+      <ul className="mt-4 space-y-3">
+        {distribution.map((segment) => (
+          <li key={segment.level}>
+            <div className="flex items-center justify-between text-sm text-slate-500">
+              <span>{segment.label}</span>
+              <span>{segment.count}</span>
+            </div>
+            <Progress value={(segment.count / total) * 100} className="mt-2 h-2" />
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+};
+
+export default MasteryOverview;

--- a/ielts-vocabulary-app/frontend/src/pages/home/components/StudyPlanCard.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/components/StudyPlanCard.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Progress } from '../../../components/ui/progress';
+import { StudyPlan } from '../insights';
+
+interface StudyPlanCardProps {
+  plan: StudyPlan;
+}
+
+const StudyPlanCard: React.FC<StudyPlanCardProps> = ({ plan }) => {
+  const completion = Math.min((plan.dueCount / plan.target) * 100, 100);
+
+  return (
+    <section className="rounded-3xl bg-white p-6 shadow-sm">
+      <h2 className="text-xl font-semibold text-slate-900">Kế hoạch hôm nay</h2>
+      <p className="mt-2 text-sm text-slate-500">{plan.focusMessage}</p>
+      <div className="mt-4">
+        <div className="flex items-center justify-between text-sm text-slate-500">
+          <span>Lượt ôn đến hạn</span>
+          <span>
+            {plan.dueCount}/{plan.target}
+          </span>
+        </div>
+        <Progress value={completion} className="mt-2 h-2" />
+      </div>
+      <div className="mt-4 rounded-2xl bg-indigo-50 px-4 py-3 text-sm text-indigo-700">
+        <p>
+          <span className="font-semibold">Từ mới gợi ý:</span> {plan.newWords}
+        </p>
+        <p className="mt-1">{plan.nextReviewMessage}</p>
+      </div>
+    </section>
+  );
+};
+
+export default StudyPlanCard;

--- a/ielts-vocabulary-app/frontend/src/pages/home/insights.ts
+++ b/ielts-vocabulary-app/frontend/src/pages/home/insights.ts
@@ -1,0 +1,94 @@
+import { UserProgress } from '../../types';
+
+export interface LevelSegment {
+  level: number;
+  label: string;
+  count: number;
+}
+
+export interface StudyPlan {
+  target: number;
+  dueCount: number;
+  newWords: number;
+  focusMessage: string;
+  nextReviewMessage: string;
+}
+
+const levelLabels: Record<number, string> = {
+  0: 'Mới bắt đầu (Lv 0)',
+  1: 'Đang làm quen (Lv 1)',
+  2: 'Cần củng cố (Lv 2)',
+  3: 'Tiến bộ tốt (Lv 3)',
+  4: 'Gần thành thạo (Lv 4)',
+  5: 'Đã thành thạo (Lv 5)',
+};
+
+export const emptyDistribution: LevelSegment[] = Object.keys(levelLabels).map((key) => ({
+  level: Number(key),
+  label: levelLabels[Number(key)],
+  count: 0,
+}));
+
+export const defaultStudyPlan: StudyPlan = {
+  target: 15,
+  dueCount: 0,
+  newWords: 5,
+  focusMessage: 'Hoàn thiện lịch học với các từ mới phù hợp.',
+  nextReviewMessage: 'Chưa có lịch ôn tiếp theo.',
+};
+
+export const buildLevelDistribution = (progress: UserProgress[]): LevelSegment[] => {
+  const counts = new Map<number, number>();
+  progress.forEach((item) => {
+    counts.set(item.level, (counts.get(item.level) || 0) + 1);
+  });
+
+  return emptyDistribution.map((segment) => ({
+    ...segment,
+    count: counts.get(segment.level) || 0,
+  }));
+};
+
+const formatRelativeDate = (date: Date) => {
+  const now = new Date();
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const diffDays = Math.round((date.setHours(0, 0, 0, 0) - now.setHours(0, 0, 0, 0)) / msPerDay);
+
+  if (diffDays <= 0) return 'Hôm nay';
+  if (diffDays === 1) return 'Ngày mai';
+  if (diffDays <= 7) return `Trong ${diffDays} ngày tới`;
+  return date.toLocaleDateString('vi-VN', { day: '2-digit', month: '2-digit' });
+};
+
+const resolveNextReviewMessage = (progress: UserProgress[]) => {
+  const upcoming = progress
+    .map((item) => new Date(item.nextReviewDate))
+    .filter((date) => !Number.isNaN(date.getTime()))
+    .sort((a, b) => a.getTime() - b.getTime());
+
+  if (upcoming.length === 0) {
+    return 'Chưa có lịch ôn tiếp theo.';
+  }
+
+  return `Ôn tiếp vào ${formatRelativeDate(upcoming[0])}`;
+};
+
+export const buildStudyPlan = (progress: UserProgress[], dueCount: number): StudyPlan => {
+  const target = 15;
+  const remainingCapacity = Math.max(target - dueCount, 0);
+  const newWords = remainingCapacity === 0 ? 0 : Math.max(3, remainingCapacity);
+  const focusMessage =
+    dueCount === 0
+      ? `Bắt đầu chu kỳ mới với ${newWords} từ mới.`
+      : dueCount >= target
+      ? `Ưu tiên hoàn tất ${dueCount} lượt ôn đến hạn.`
+      : `Hoàn tất ${dueCount} lượt ôn và thêm ${newWords} từ mới.`;
+
+  return {
+    target,
+    dueCount,
+    newWords,
+    focusMessage,
+    nextReviewMessage: resolveNextReviewMessage(progress),
+  };
+};

--- a/ielts-vocabulary-app/frontend/src/pages/home/useDashboardData.ts
+++ b/ielts-vocabulary-app/frontend/src/pages/home/useDashboardData.ts
@@ -2,10 +2,20 @@ import { useEffect, useState } from 'react';
 import { userAPI } from '../../services/api';
 import { StudySession } from '../../types';
 import { buildStats, emptyStats, DashboardStats } from './utils';
+import {
+  buildLevelDistribution,
+  buildStudyPlan,
+  defaultStudyPlan,
+  emptyDistribution,
+  LevelSegment,
+  StudyPlan,
+} from './insights';
 
 const useDashboardData = () => {
   const [stats, setStats] = useState<DashboardStats>(emptyStats);
   const [dueVocabulary, setDueVocabulary] = useState<StudySession[]>([]);
+  const [levelDistribution, setLevelDistribution] = useState<LevelSegment[]>(emptyDistribution);
+  const [studyPlan, setStudyPlan] = useState<StudyPlan>(defaultStudyPlan);
   const [isLoading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -17,6 +27,8 @@ const useDashboardData = () => {
         ]);
         setStats(buildStats(progressData, dueData.length));
         setDueVocabulary(dueData);
+        setLevelDistribution(buildLevelDistribution(progressData));
+        setStudyPlan(buildStudyPlan(progressData, dueData.length));
       } catch (error) {
         console.error('Error loading dashboard data', error);
       } finally {
@@ -27,7 +39,7 @@ const useDashboardData = () => {
     fetchData();
   }, []);
 
-  return { stats, dueVocabulary, isLoading };
+  return { stats, dueVocabulary, levelDistribution, studyPlan, isLoading };
 };
 
 export default useDashboardData;


### PR DESCRIPTION
## Summary
- add study plan and mastery overview cards to the authenticated home dashboard
- compute level distribution and daily study plan insights from user progress data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de3e2a2ed48328bab1250788d1e36e