### PR TITLE
Enhance landing visuals with illustrations and mastery chart

### DIFF
--- a/ielts-vocabulary-app/frontend/src/assets/hero-illustration.svg
+++ b/ielts-vocabulary-app/frontend/src/assets/hero-illustration.svg
@@ -1,0 +1,56 @@
+<svg width="480" height="360" viewBox="0 0 480 360" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bgGradient" x1="62" y1="52" x2="420" y2="308" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#EEF2FF" />
+      <stop offset="1" stop-color="#C7D2FE" />
+    </linearGradient>
+    <linearGradient id="accentGradient" x1="140" y1="72" x2="340" y2="288" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#6366F1" />
+      <stop offset="1" stop-color="#8B5CF6" />
+    </linearGradient>
+    <linearGradient id="cardGradient" x1="40" y1="-10" x2="180" y2="130" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFFFFF" stop-opacity="0.9" />
+      <stop offset="1" stop-color="#E0E7FF" stop-opacity="0.6" />
+    </linearGradient>
+    <filter id="dropShadow" x="0" y="0" width="480" height="360" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feOffset dy="12" />
+      <feGaussianBlur stdDeviation="22" result="blur" />
+      <feColorMatrix type="matrix" values="0 0 0 0 0.38 0 0 0 0 0.46 0 0 0 0 0.97 0 0 0 0.18 0" />
+      <feBlend in2="SourceGraphic" result="shape" />
+    </filter>
+  </defs>
+  <rect x="32" y="28" width="416" height="300" rx="32" fill="url(#bgGradient)" filter="url(#dropShadow)" />
+  <g transform="translate(80 64)">
+    <rect x="0" y="0" width="200" height="120" rx="18" fill="url(#cardGradient)" />
+    <rect x="22" y="28" width="156" height="12" rx="6" fill="#3730A3" fill-opacity="0.85" />
+    <rect x="22" y="52" width="132" height="10" rx="5" fill="#4C1D95" fill-opacity="0.25" />
+    <rect x="22" y="74" width="96" height="10" rx="5" fill="#4C1D95" fill-opacity="0.2" />
+    <circle cx="46" cy="96" r="8" fill="#6366F1" />
+    <circle cx="82" cy="96" r="8" fill="#A855F7" />
+    <circle cx="118" cy="96" r="8" fill="#C084FC" />
+  </g>
+  <g transform="translate(262 86)">
+    <rect x="0" y="0" width="152" height="192" rx="28" fill="white" fill-opacity="0.92" />
+    <rect x="24" y="48" width="104" height="16" rx="8" fill="#312E81" fill-opacity="0.9" />
+    <rect x="24" y="76" width="104" height="14" rx="7" fill="#6366F1" fill-opacity="0.25" />
+    <rect x="24" y="102" width="104" height="14" rx="7" fill="#6366F1" fill-opacity="0.18" />
+    <g transform="translate(24 138)">
+      <circle cx="22" cy="22" r="22" fill="url(#accentGradient)" />
+      <path d="M18 23.5l4.2 4.2 10-10.2" stroke="white" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+    </g>
+    <g transform="translate(68 18)">
+      <circle cx="20" cy="20" r="20" fill="#EEF2FF" />
+      <path d="M12 22h16M20 14v16" stroke="#4338CA" stroke-width="4" stroke-linecap="round" />
+    </g>
+  </g>
+  <g transform="translate(112 230)">
+    <rect x="0" y="0" width="120" height="72" rx="18" fill="#312E81" fill-opacity="0.85" />
+    <path d="M24 48c12-20 24-24 48-36 12-6 24 12 36 6 12-6 12-30 24-36" stroke="#C4B5FD" stroke-width="6" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+    <circle cx="28" cy="46" r="6" fill="#FACC15" />
+    <circle cx="76" cy="26" r="6" fill="#F472B6" />
+    <circle cx="100" cy="10" r="6" fill="#22D3EE" />
+  </g>
+  <circle cx="98" cy="102" r="18" fill="#4C1D95" fill-opacity="0.35" />
+  <circle cx="398" cy="86" r="14" fill="#A855F7" fill-opacity="0.28" />
+  <circle cx="384" cy="256" r="22" fill="#3730A3" fill-opacity="0.18" />
+</svg>

--- a/ielts-vocabulary-app/frontend/src/assets/index.ts
+++ b/ielts-vocabulary-app/frontend/src/assets/index.ts
@@ -1,0 +1,2 @@
+export { default as heroIllustration } from './hero-illustration.svg';
+export { default as stepsIllustration } from './steps-illustration.svg';

--- a/ielts-vocabulary-app/frontend/src/assets/steps-illustration.svg
+++ b/ielts-vocabulary-app/frontend/src/assets/steps-illustration.svg
@@ -1,0 +1,11 @@
+<svg width="260" height="160" viewBox="0 0 260 160" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="12" y="20" width="236" height="124" rx="24" fill="#EEF2FF" />
+  <path d="M44 120L76 88L96 108L140 64L168 92L212 52" stroke="#6366F1" stroke-width="10" stroke-linecap="round" stroke-linejoin="round" fill="none" />
+  <circle cx="76" cy="88" r="12" fill="#4C1D95" />
+  <circle cx="96" cy="108" r="10" fill="#A855F7" />
+  <circle cx="140" cy="64" r="14" fill="#38BDF8" />
+  <circle cx="168" cy="92" r="11" fill="#F97316" />
+  <circle cx="212" cy="52" r="13" fill="#22C55E" />
+  <rect x="46" y="40" width="64" height="16" rx="8" fill="#6366F1" fill-opacity="0.25" />
+  <rect x="46" y="64" width="84" height="12" rx="6" fill="#6366F1" fill-opacity="0.15" />
+</svg>

--- a/ielts-vocabulary-app/frontend/src/pages/home/components/HeroSection.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/components/HeroSection.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { heroIllustration } from '../../../assets';
 import { Button } from '../../../components/ui/button';
 
 interface HeroSectionProps {
@@ -6,22 +7,35 @@ interface HeroSectionProps {
 }
 
 const HeroSection: React.FC<HeroSectionProps> = ({ onLogin }) => (
-  <section className="bg-white">
-    <div className="mx-auto max-w-5xl px-6 py-16 text-slate-900">
-      <p className="text-sm font-semibold text-indigo-600">Học từ vựng IELTS chủ động</p>
-      <h1 className="mt-4 text-4xl font-bold sm:text-5xl">
-        Tập trung ghi nhớ từ vựng trọng tâm mỗi ngày
-      </h1>
-      <p className="mt-4 max-w-2xl text-base text-slate-600 sm:text-lg">
-        Nắm chắc nghĩa, ví dụ và cách dùng của từng từ với lộ trình ôn luyện thông minh.
-      </p>
-      <div className="mt-8 flex flex-col gap-3 sm:flex-row">
-        <Button size="lg" className="rounded-full px-6" onClick={onLogin}>
-          Bắt đầu học với Google
-        </Button>
-        <span className="text-sm text-slate-500 sm:self-center">
-          Hoàn toàn miễn phí, đồng bộ trên mọi thiết bị.
-        </span>
+  <section className="relative overflow-hidden bg-gradient-to-br from-white via-indigo-50 to-slate-100">
+    <div className="pointer-events-none absolute inset-x-0 top-0 h-64 bg-[radial-gradient(circle_at_top,rgba(79,70,229,0.18),transparent_60%)]" />
+    <div className="relative mx-auto flex max-w-6xl flex-col items-center gap-12 px-6 py-16 text-slate-900 md:flex-row md:gap-16">
+      <div className="max-w-xl text-center md:text-left">
+        <p className="text-sm font-semibold uppercase tracking-wide text-indigo-600">Học từ vựng IELTS chủ động</p>
+        <h1 className="mt-4 text-4xl font-bold sm:text-5xl">
+          Tập trung ghi nhớ từ vựng trọng tâm mỗi ngày
+        </h1>
+        <p className="mt-4 text-base text-slate-600 sm:text-lg">
+          Nắm chắc nghĩa, ví dụ và cách dùng của từng từ với lộ trình ôn luyện thông minh cùng biểu đồ tiến bộ trực quan.
+        </p>
+        <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row md:items-start">
+          <Button size="lg" className="rounded-full px-6" onClick={onLogin}>
+            Bắt đầu học với Google
+          </Button>
+          <span className="text-sm text-slate-500 sm:self-center md:self-start">
+            Hoàn toàn miễn phí, đồng bộ trên mọi thiết bị.
+          </span>
+        </div>
+      </div>
+      <div className="relative w-full max-w-md">
+        <div className="absolute -left-6 -top-6 h-16 w-16 rounded-3xl bg-indigo-200/40 blur-2xl" />
+        <div className="absolute -bottom-8 -right-8 h-24 w-24 rounded-full bg-violet-200/50 blur-3xl" />
+        <img
+          src={heroIllustration}
+          alt="Học từ vựng IELTS với biểu đồ và thẻ ghi nhớ"
+          className="relative w-full drop-shadow-2xl"
+          loading="lazy"
+        />
       </div>
     </div>
   </section>

--- a/ielts-vocabulary-app/frontend/src/pages/home/components/LearningSteps.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/components/LearningSteps.tsx
@@ -1,18 +1,37 @@
 import React from 'react';
+import { stepsIllustration } from '../../../assets';
 import { learningSteps } from '../constants';
 
 const LearningSteps: React.FC = () => (
   <section className="rounded-3xl border border-slate-100 bg-white p-8">
-    <h2 className="text-2xl font-semibold text-slate-900">Lộ trình học 4 bước</h2>
-    <ol className="mt-6 grid gap-4 sm:grid-cols-2">
-      {learningSteps.map((step, index) => (
-        <li key={step.title} className="rounded-2xl bg-slate-50 p-4">
-          <span className="text-sm font-semibold text-indigo-600">Bước {index + 1}</span>
-          <h3 className="mt-2 text-lg font-medium text-slate-900">{step.title}</h3>
-          <p className="mt-1 text-sm text-slate-600">{step.description}</p>
-        </li>
-      ))}
-    </ol>
+    <div className="flex flex-col gap-6 md:flex-row md:items-center">
+      <div className="mx-auto max-w-xs md:mx-0 md:w-2/5">
+        <img
+          src={stepsIllustration}
+          alt="Biểu đồ lộ trình học từng bước"
+          className="w-full"
+          loading="lazy"
+        />
+      </div>
+      <div className="md:flex-1">
+        <h2 className="text-2xl font-semibold text-slate-900">Lộ trình học 4 bước</h2>
+        <p className="mt-2 text-sm text-slate-500">
+          Bắt đầu nhẹ nhàng và theo dõi tiến bộ rõ ràng với từng bước học được minh hoạ trực quan.
+        </p>
+        <ol className="mt-6 grid gap-4 sm:grid-cols-2">
+          {learningSteps.map((step, index) => (
+            <li key={step.title} className="relative overflow-hidden rounded-2xl border border-slate-100 bg-slate-50 p-4">
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100 text-sm font-semibold text-indigo-600">
+                {index + 1}
+              </span>
+              <h3 className="mt-3 text-lg font-medium text-slate-900">{step.title}</h3>
+              <p className="mt-1 text-sm text-slate-600">{step.description}</p>
+              <span className="pointer-events-none absolute -right-10 -top-10 h-20 w-20 rounded-full bg-indigo-200/50" />
+            </li>
+          ))}
+        </ol>
+      </div>
+    </div>
   </section>
 );
 

--- a/ielts-vocabulary-app/frontend/src/pages/home/components/MasteryOverview.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/components/MasteryOverview.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Progress } from '../../../components/ui/progress';
 import { LevelSegment } from '../insights';
 
 interface MasteryOverviewProps {
@@ -7,22 +6,77 @@ interface MasteryOverviewProps {
 }
 
 const MasteryOverview: React.FC<MasteryOverviewProps> = ({ distribution }) => {
-  const total = distribution.reduce((sum, item) => sum + item.count, 0) || 1;
+  const totalCount = distribution.reduce((sum, item) => sum + item.count, 0);
+  const safeTotal = totalCount || 1;
+  const palette = ['#6366F1', '#A855F7', '#F97316', '#0EA5E9', '#22C55E'];
+  const segments = distribution.map((segment, index) => ({
+    ...segment,
+    color: palette[index % palette.length],
+    percentage: totalCount ? Math.round((segment.count / safeTotal) * 100) : 0,
+  }));
+  const radius = 64;
+  const circumference = 2 * Math.PI * radius;
+  let cumulative = 0;
 
   return (
     <section className="rounded-3xl bg-white p-6 shadow-sm">
       <h2 className="text-xl font-semibold text-slate-900">Mức độ thuần thục</h2>
-      <ul className="mt-4 space-y-3">
-        {distribution.map((segment) => (
-          <li key={segment.level}>
-            <div className="flex items-center justify-between text-sm text-slate-500">
-              <span>{segment.label}</span>
-              <span>{segment.count}</span>
-            </div>
-            <Progress value={(segment.count / total) * 100} className="mt-2 h-2" />
-          </li>
-        ))}
-      </ul>
+      <p className="mt-1 text-sm text-slate-500">Theo dõi sự phân bổ từ vựng của bạn theo từng cấp độ ghi nhớ.</p>
+      <div className="mt-6 flex flex-col gap-6 sm:flex-row sm:items-center">
+        <div className="relative mx-auto flex h-48 w-48 items-center justify-center">
+          <svg viewBox="0 0 200 200" className="h-full w-full rotate-[-90deg]">
+            <circle cx="100" cy="100" r={radius} stroke="#E0E7FF" strokeWidth="20" fill="none" />
+            {segments.map((segment) => {
+              const value = segment.count / safeTotal;
+              const dashArray = `${value * circumference} ${circumference}`;
+              const dashOffset = circumference * (1 - cumulative);
+              cumulative += value;
+
+              return (
+                <circle
+                  key={segment.level}
+                  cx="100"
+                  cy="100"
+                  r={radius}
+                  stroke={segment.color}
+                  strokeWidth="20"
+                  strokeLinecap="round"
+                  strokeDasharray={dashArray}
+                  strokeDashoffset={dashOffset}
+                  fill="none"
+                />
+              );
+            })}
+          </svg>
+          <div className="absolute flex flex-col items-center justify-center text-center">
+            <span className="text-3xl font-semibold text-slate-900">{totalCount}</span>
+            <span className="text-xs uppercase tracking-wide text-slate-500">từ đã học</span>
+          </div>
+        </div>
+        <ul className="flex-1 space-y-3">
+          {segments.map((segment) => (
+            <li
+              key={segment.level}
+              className="flex items-center justify-between gap-4 rounded-2xl bg-slate-50 px-4 py-3"
+            >
+              <div className="flex items-center gap-3">
+                <span
+                  className="h-3 w-3 rounded-full"
+                  style={{ backgroundColor: segment.color }}
+                  aria-hidden
+                />
+                <div>
+                  <p className="text-sm font-semibold text-slate-900">{segment.label}</p>
+                  <p className="text-xs text-slate-500">
+                    {segment.count} từ • {segment.percentage}%
+                  </p>
+                </div>
+              </div>
+              <span className="text-sm font-medium text-slate-600">{segment.percentage}%</span>
+            </li>
+          ))}
+        </ul>
+      </div>
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- add custom illustrations to the hero and learning steps sections to enrich the guest landing page
- visualize mastery distribution with a colorful donut chart and legend for a livelier dashboard

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de42e501748328a6533fe82f03d103