### PR TITLE
Refine home landing page with minimalist styling

### DIFF
--- a/ielts-vocabulary-app/frontend/src/pages/home/components/HeroSection.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/components/HeroSection.tsx
@@ -7,35 +7,59 @@ interface HeroSectionProps {
 }
 
 const HeroSection: React.FC<HeroSectionProps> = ({ onLogin }) => (
-  <section className="relative overflow-hidden bg-gradient-to-br from-white via-indigo-50 to-slate-100">
-    <div className="pointer-events-none absolute inset-x-0 top-0 h-64 bg-[radial-gradient(circle_at_top,rgba(79,70,229,0.18),transparent_60%)]" />
-    <div className="relative mx-auto flex max-w-6xl flex-col items-center gap-12 px-6 py-16 text-slate-900 md:flex-row md:gap-16">
-      <div className="max-w-xl text-center md:text-left">
-        <p className="text-sm font-semibold uppercase tracking-wide text-indigo-600">Học từ vựng IELTS chủ động</p>
-        <h1 className="mt-4 text-4xl font-bold sm:text-5xl">
-          Tập trung ghi nhớ từ vựng trọng tâm mỗi ngày
+  <section className="relative overflow-hidden bg-white">
+    <div className="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(15,23,42,0.08),transparent_60%)]" />
+    <div className="relative mx-auto flex max-w-6xl flex-col-reverse items-center gap-16 px-6 py-20 md:flex-row md:gap-20">
+      <div className="flex w-full max-w-xl flex-col items-center text-center md:items-start md:text-left">
+        <span className="inline-flex items-center rounded-full border border-slate-200 px-4 py-1 text-xs font-medium tracking-widest text-slate-500">
+          Lộ trình học tinh gọn
+        </span>
+        <h1 className="mt-6 text-4xl font-semibold leading-tight text-slate-900 sm:text-5xl">
+          Ghi nhớ từ vựng IELTS với giao diện tối giản, không xao nhãng
         </h1>
         <p className="mt-4 text-base text-slate-600 sm:text-lg">
-          Nắm chắc nghĩa, ví dụ và cách dùng của từng từ với lộ trình ôn luyện thông minh cùng biểu đồ tiến bộ trực quan.
+          Tập trung vào những từ quan trọng nhất mỗi ngày cùng thẻ học trực quan, thống kê tối giản và nhắc học thông minh.
         </p>
-        <div className="mt-8 flex flex-col items-center gap-3 sm:flex-row md:items-start">
-          <Button size="lg" className="rounded-full px-6" onClick={onLogin}>
-            Bắt đầu học với Google
+        <ul className="mt-6 space-y-3 text-sm text-slate-600">
+          {[
+            'Theo dõi tiến độ rõ ràng trên một bảng điều khiển duy nhất',
+            'Cấu trúc bài học ngắn gọn, phù hợp cho 15 phút mỗi ngày',
+            'Đồng bộ trên mọi thiết bị với tài khoản Google của bạn',
+          ].map((item) => (
+            <li key={item} className="flex items-start gap-3">
+              <span className="mt-1 h-2 w-2 rounded-full bg-slate-900" />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-8 flex w-full flex-col gap-3 sm:flex-row sm:items-center">
+          <Button
+            size="lg"
+            className="h-12 w-full rounded-full bg-slate-900 text-base font-semibold text-white hover:bg-slate-900/90 sm:w-auto sm:px-8"
+            onClick={onLogin}
+          >
+            Bắt đầu học miễn phí
           </Button>
-          <span className="text-sm text-slate-500 sm:self-center md:self-start">
-            Hoàn toàn miễn phí, đồng bộ trên mọi thiết bị.
-          </span>
+          <Button
+            variant="ghost"
+            className="text-sm text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+            onClick={onLogin}
+          >
+            Xem trải nghiệm mẫu
+          </Button>
         </div>
       </div>
-      <div className="relative w-full max-w-md">
-        <div className="absolute -left-6 -top-6 h-16 w-16 rounded-3xl bg-indigo-200/40 blur-2xl" />
-        <div className="absolute -bottom-8 -right-8 h-24 w-24 rounded-full bg-violet-200/50 blur-3xl" />
-        <img
-          src={heroIllustration}
-          alt="Học từ vựng IELTS với biểu đồ và thẻ ghi nhớ"
-          className="relative w-full drop-shadow-2xl"
-          loading="lazy"
-        />
+      <div className="relative flex w-full max-w-md justify-center">
+        <div className="absolute -top-12 left-1/2 h-32 w-32 -translate-x-1/2 rounded-full bg-slate-200/60 blur-2xl" />
+        <div className="absolute -bottom-10 right-4 h-20 w-20 rounded-full bg-slate-100" />
+        <div className="relative overflow-hidden rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <img
+            src={heroIllustration}
+            alt="Học từ vựng IELTS với biểu đồ và thẻ ghi nhớ"
+            className="w-full"
+            loading="lazy"
+          />
+        </div>
       </div>
     </div>
   </section>

--- a/ielts-vocabulary-app/frontend/src/pages/home/components/HighlightsGrid.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/components/HighlightsGrid.tsx
@@ -2,17 +2,22 @@ import React from 'react';
 import { keyFeatures } from '../constants';
 
 const HighlightsGrid: React.FC = () => (
-  <section className="rounded-3xl bg-white p-8 shadow-sm">
-    <h2 className="text-2xl font-semibold text-slate-900">Những điểm mạnh chính</h2>
-    <div className="mt-6 grid gap-6 sm:grid-cols-2">
+  <section className="rounded-3xl border border-slate-200 bg-white px-8 py-10">
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+      <h2 className="text-2xl font-semibold text-slate-900">Những điểm mạnh chính</h2>
+      <p className="max-w-md text-sm text-slate-500">
+        Lựa chọn các tính năng cần thiết giúp bạn tập trung học từng ngày mà không bị choáng ngợp.
+      </p>
+    </div>
+    <div className="mt-8 grid gap-6 sm:grid-cols-2">
       {keyFeatures.map(({ icon: Icon, title, description }) => (
-        <article key={title} className="flex gap-4">
-          <span className="flex h-12 w-12 items-center justify-center rounded-full bg-indigo-50 text-indigo-600">
+        <article key={title} className="flex gap-4 rounded-2xl border border-slate-100 p-5 transition hover:border-slate-200">
+          <span className="flex h-11 w-11 items-center justify-center rounded-full bg-slate-100 text-slate-700">
             <Icon className="h-5 w-5" />
           </span>
-          <div>
-            <h3 className="text-lg font-semibold text-slate-900">{title}</h3>
-            <p className="mt-1 text-sm text-slate-600">{description}</p>
+          <div className="space-y-1">
+            <h3 className="text-base font-semibold text-slate-900">{title}</h3>
+            <p className="text-sm text-slate-600">{description}</p>
           </div>
         </article>
       ))}

--- a/ielts-vocabulary-app/frontend/src/pages/home/components/LearningSteps.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/components/LearningSteps.tsx
@@ -3,30 +3,34 @@ import { stepsIllustration } from '../../../assets';
 import { learningSteps } from '../constants';
 
 const LearningSteps: React.FC = () => (
-  <section className="rounded-3xl border border-slate-100 bg-white p-8">
-    <div className="flex flex-col gap-6 md:flex-row md:items-center">
-      <div className="mx-auto max-w-xs md:mx-0 md:w-2/5">
-        <img
-          src={stepsIllustration}
-          alt="Biểu đồ lộ trình học từng bước"
-          className="w-full"
-          loading="lazy"
-        />
+  <section className="rounded-3xl border border-slate-200 bg-white px-8 py-10">
+    <div className="flex flex-col gap-8 md:flex-row md:items-center">
+      <div className="mx-auto w-full max-w-xs md:mx-0 md:w-2/5">
+        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-slate-50 p-4">
+          <img
+            src={stepsIllustration}
+            alt="Biểu đồ lộ trình học từng bước"
+            className="w-full"
+            loading="lazy"
+          />
+        </div>
       </div>
       <div className="md:flex-1">
         <h2 className="text-2xl font-semibold text-slate-900">Lộ trình học 4 bước</h2>
-        <p className="mt-2 text-sm text-slate-500">
-          Bắt đầu nhẹ nhàng và theo dõi tiến bộ rõ ràng với từng bước học được minh hoạ trực quan.
+        <p className="mt-3 text-sm text-slate-500">
+          Mỗi bước tập trung vào một nhiệm vụ rõ ràng để bạn dễ dàng hoàn thành trong khoảng thời gian ngắn.
         </p>
-        <ol className="mt-6 grid gap-4 sm:grid-cols-2">
+        <ol className="mt-8 grid gap-4 md:grid-cols-2">
           {learningSteps.map((step, index) => (
-            <li key={step.title} className="relative overflow-hidden rounded-2xl border border-slate-100 bg-slate-50 p-4">
-              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-indigo-100 text-sm font-semibold text-indigo-600">
+            <li
+              key={step.title}
+              className="group relative flex flex-col gap-2 rounded-2xl border border-slate-100 p-5 transition hover:border-slate-200"
+            >
+              <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-slate-900 text-xs font-semibold text-white">
                 {index + 1}
               </span>
-              <h3 className="mt-3 text-lg font-medium text-slate-900">{step.title}</h3>
-              <p className="mt-1 text-sm text-slate-600">{step.description}</p>
-              <span className="pointer-events-none absolute -right-10 -top-10 h-20 w-20 rounded-full bg-indigo-200/50" />
+              <h3 className="text-base font-semibold text-slate-900">{step.title}</h3>
+              <p className="text-sm text-slate-600">{step.description}</p>
             </li>
           ))}
         </ol>


### PR DESCRIPTION
## Summary
- restyle the guest hero section with a minimalist layout, concise copy and framed illustration
- simplify highlight cards and learning steps with clean borders, spacing and muted palette to match the minimalist direction

## Testing
- npm run test -- --watchAll=false *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68de4626f4ec8328b48ab8d18eeece23