### PR TITLE
Load daily quote from Google Books API

### DIFF
--- a/ielts-vocabulary-app/frontend/src/components/DailyMotivationQuote.tsx
+++ b/ielts-vocabulary-app/frontend/src/components/DailyMotivationQuote.tsx
@@ -1,0 +1,113 @@
+import React, { useEffect, useState } from 'react';
+import {
+  MotivationQuote,
+  fetchGoogleMotivationQuote,
+  getFallbackQuote,
+} from '../lib/motivationalQuotes';
+import { cn } from '../lib/utils';
+
+interface DailyMotivationQuoteProps {
+  className?: string;
+}
+
+const DailyMotivationQuote: React.FC<DailyMotivationQuoteProps> = ({ className }) => {
+  const [quote, setQuote] = useState<MotivationQuote | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+    const storageKey = 'daily-motivation-quote';
+
+    const loadQuote = async () => {
+      if (typeof window === 'undefined' || typeof window.localStorage === 'undefined') {
+        const fallbackQuote = getFallbackQuote();
+        setQuote(fallbackQuote);
+        setIsLoading(false);
+        return;
+      }
+
+      const todayKey = new Date().toISOString().split('T')[0];
+
+      try {
+        const cached = localStorage.getItem(storageKey);
+
+        if (cached) {
+          const parsed = JSON.parse(cached) as { quote: MotivationQuote; date: string };
+
+          if (parsed?.date === todayKey) {
+            setQuote(parsed.quote);
+            setIsLoading(false);
+            return;
+          }
+        }
+      } catch (error) {
+        console.error('Unable to read cached motivation quote', error);
+      }
+
+      try {
+        const googleQuote = await fetchGoogleMotivationQuote();
+
+        if (!isMounted) {
+          return;
+        }
+
+        setQuote(googleQuote);
+
+        try {
+          localStorage.setItem(storageKey, JSON.stringify({ quote: googleQuote, date: todayKey }));
+        } catch (error) {
+          console.warn('Unable to cache Google motivation quote', error);
+        }
+      } catch (error) {
+        console.warn('Falling back to local motivation quote list', error);
+
+        if (!isMounted) {
+          return;
+        }
+
+        const fallbackQuote = getFallbackQuote();
+        setQuote(fallbackQuote);
+
+        try {
+          localStorage.setItem(storageKey, JSON.stringify({ quote: fallbackQuote, date: todayKey }));
+        } catch (storageError) {
+          console.warn('Unable to cache fallback motivation quote', storageError);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void loadQuote();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return (
+    <figure
+      className={cn(
+        'rounded-2xl border border-slate-200 bg-white/90 p-6 text-slate-700 shadow-sm backdrop-blur',
+        className,
+      )}
+    >
+      <blockquote className="text-base italic leading-relaxed text-slate-800 sm:text-lg">
+        {isLoading ? (
+          <span className="inline-flex animate-pulse select-none rounded bg-slate-200/80 px-2 py-1 text-transparent">
+            Loading daily motivation…
+          </span>
+        ) : (
+          <>“{quote?.text ?? 'Keep moving forward.'}”</>
+        )}
+      </blockquote>
+      {!isLoading && quote?.author ? (
+        <figcaption className="mt-4 text-sm font-medium text-slate-500">— {quote.author}</figcaption>
+      ) : null}
+    </figure>
+  );
+};
+
+export default DailyMotivationQuote;

--- a/ielts-vocabulary-app/frontend/src/lib/motivationalQuotes.ts
+++ b/ielts-vocabulary-app/frontend/src/lib/motivationalQuotes.ts
@@ -1,0 +1,156 @@
+export interface MotivationQuote {
+  text: string;
+  author: string;
+}
+
+const fallbackQuotes: MotivationQuote[] = [
+  { text: 'The future depends on what you do today.', author: 'Mahatma Gandhi' },
+  { text: 'Success is the sum of small efforts repeated day in and day out.', author: 'Robert Collier' },
+  { text: 'Believe you can and you are halfway there.', author: 'Theodore Roosevelt' },
+  { text: 'Start where you are. Use what you have. Do what you can.', author: 'Arthur Ashe' },
+  { text: 'Discipline is the bridge between goals and accomplishment.', author: 'Jim Rohn' },
+  { text: 'Great things are done by a series of small things brought together.', author: 'Vincent van Gogh' },
+  { text: 'Every day is a chance to get better. Don’t waste it.', author: 'Unknown' },
+  { text: 'The secret of getting ahead is getting started.', author: 'Mark Twain' },
+  { text: 'Small progress is still progress.', author: 'Unknown' },
+  { text: 'Dream big. Start small. Act now.', author: 'Robin Sharma' },
+  { text: 'Success usually comes to those who are too busy to be looking for it.', author: 'Henry David Thoreau' },
+  { text: 'Focus on being productive instead of busy.', author: 'Tim Ferriss' },
+  { text: 'Quality is not an act, it is a habit.', author: 'Aristotle' },
+  { text: 'It always seems impossible until it is done.', author: 'Nelson Mandela' },
+  { text: 'You don’t have to be great to start, but you have to start to be great.', author: 'Zig Ziglar' },
+  { text: 'What you do today can improve all your tomorrows.', author: 'Ralph Marston' },
+  { text: 'Your limitation—it is only your imagination.', author: 'Unknown' },
+  { text: 'Push yourself, because no one else is going to do it for you.', author: 'Unknown' },
+  { text: 'The way to get started is to quit talking and begin doing.', author: 'Walt Disney' },
+  { text: 'Well done is better than well said.', author: 'Benjamin Franklin' },
+];
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
+
+const getDayOfYear = (date: Date) => {
+  const startOfYear = new Date(Date.UTC(date.getUTCFullYear(), 0, 1));
+  const diff = date.getTime() - startOfYear.getTime();
+  return Math.floor(diff / ONE_DAY_MS);
+};
+
+const stripHtml = (value: string) => value.replace(/<[^>]*>/g, ' ');
+
+const decodeHtmlEntities = (value: string) =>
+  value.replace(/&(#\d+|#x[\da-f]+|[a-z]+);/gi, (entity) => {
+    if (entity.startsWith('&#x')) {
+      return String.fromCharCode(parseInt(entity.slice(3, -1), 16));
+    }
+
+    if (entity.startsWith('&#')) {
+      return String.fromCharCode(parseInt(entity.slice(2, -1), 10));
+    }
+
+    switch (entity) {
+      case '&quot;':
+        return '"';
+      case '&apos;':
+      case '&#39;':
+        return "'";
+      case '&amp;':
+        return '&';
+      case '&lt;':
+        return '<';
+      case '&gt;':
+        return '>';
+      default:
+        return entity;
+    }
+  });
+
+const normaliseQuoteText = (value: string) => {
+  const cleaned = decodeHtmlEntities(stripHtml(value)).replace(/\s+/g, ' ').trim();
+
+  return cleaned
+    .replace(/^…\s*/u, '')
+    .replace(/\s*…$/u, '')
+    .replace(/^"|"$/g, '')
+    .replace(/^'|'$/g, '');
+};
+
+const googleBooksEndpoint = 'https://www.googleapis.com/books/v1/volumes';
+
+type GoogleBooksItem = {
+  volumeInfo?: {
+    title?: string;
+    authors?: string[];
+    description?: string;
+  };
+  searchInfo?: {
+    textSnippet?: string;
+  };
+};
+
+const isReasonableLength = (text: string) => text.length >= 40 && text.length <= 240;
+
+const mapItemToQuote = (item: GoogleBooksItem): MotivationQuote | null => {
+  const rawText = item.searchInfo?.textSnippet ?? item.volumeInfo?.description;
+
+  if (!rawText) {
+    return null;
+  }
+
+  const text = normaliseQuoteText(rawText);
+
+  if (!text || !isReasonableLength(text)) {
+    return null;
+  }
+
+  const author = item.volumeInfo?.authors?.[0] ?? item.volumeInfo?.title ?? 'Unknown';
+
+  return {
+    text,
+    author,
+  };
+};
+
+export const fetchGoogleMotivationQuote = async (date: Date = new Date()): Promise<MotivationQuote> => {
+  const params = new URLSearchParams({
+    q: '"motivational quote" OR "inspirational quote"',
+    langRestrict: 'en',
+    maxResults: '30',
+    printType: 'books',
+    orderBy: 'relevance',
+    fields: 'items(volumeInfo/title,volumeInfo/authors,volumeInfo/description,searchInfo/textSnippet)',
+  });
+
+  const headers: Record<string, string> = {};
+
+  if (process.env.REACT_APP_GOOGLE_BOOKS_API_KEY) {
+    headers['X-Goog-Api-Key'] = process.env.REACT_APP_GOOGLE_BOOKS_API_KEY;
+  }
+
+  const response = await fetch(`${googleBooksEndpoint}?${params.toString()}`, { headers });
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch quote from Google Books');
+  }
+
+  const payload = (await response.json()) as { items?: GoogleBooksItem[] };
+  const googleQuotes = (payload.items ?? []).map(mapItemToQuote).filter(Boolean) as MotivationQuote[];
+
+  if (googleQuotes.length === 0) {
+    throw new Error('Google Books response did not contain quotes');
+  }
+
+  const dayOfYear = getDayOfYear(date);
+  const index = ((dayOfYear % googleQuotes.length) + googleQuotes.length) % googleQuotes.length;
+  return googleQuotes[index];
+};
+
+export const getFallbackQuote = (date: Date = new Date()): MotivationQuote => {
+  if (fallbackQuotes.length === 0) {
+    return { text: 'Keep moving forward.', author: 'Unknown' };
+  }
+
+  const dayOfYear = getDayOfYear(date);
+  const index = ((dayOfYear % fallbackQuotes.length) + fallbackQuotes.length) % fallbackQuotes.length;
+  return fallbackQuotes[index];
+};
+
+export default fallbackQuotes;

--- a/ielts-vocabulary-app/frontend/src/pages/home/GuestLanding.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/GuestLanding.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
+import DailyMotivationQuote from '../../components/DailyMotivationQuote';
 import HeroSection from './components/HeroSection';
-import HighlightsGrid from './components/HighlightsGrid';
 import LearningSteps from './components/LearningSteps';
 
 interface GuestLandingProps {
@@ -11,7 +11,7 @@ const GuestLanding: React.FC<GuestLandingProps> = ({ onLogin }) => (
   <div className="min-h-screen bg-slate-50">
     <HeroSection onLogin={onLogin} />
     <main className="mx-auto max-w-5xl space-y-12 px-6 pb-20">
-      <HighlightsGrid />
+      <DailyMotivationQuote className="bg-white" />
       <LearningSteps />
     </main>
   </div>

--- a/ielts-vocabulary-app/frontend/src/pages/home/LearningDashboard.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/LearningDashboard.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DailyMotivationQuote from '../../components/DailyMotivationQuote';
 import { User } from '../../types';
 import DashboardHeader from './components/DashboardHeader';
 import LearningSummary from './components/LearningSummary';
@@ -26,6 +27,7 @@ const LearningDashboard: React.FC<LearningDashboardProps> = ({
     <div className="min-h-screen bg-slate-50">
       <div className="mx-auto flex max-w-5xl flex-col gap-6 px-6 py-10">
         <DashboardHeader user={user} onStartStudy={onStartStudy} onLogout={onLogout} />
+        <DailyMotivationQuote className="border-0 bg-gradient-to-r from-indigo-500/90 to-sky-500/90 text-white shadow-lg shadow-indigo-200/40" />
         <LearningSummary stats={stats} />
         <section className="grid gap-4 md:grid-cols-2">
           <StudyPlanCard plan={studyPlan} />

--- a/ielts-vocabulary-app/frontend/src/pages/home/components/HeroSection.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/components/HeroSection.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { heroIllustration } from '../../../assets';
+import DailyMotivationQuote from '../../../components/DailyMotivationQuote';
 import { Button } from '../../../components/ui/button';
 
 interface HeroSectionProps {
@@ -20,18 +21,7 @@ const HeroSection: React.FC<HeroSectionProps> = ({ onLogin }) => (
         <p className="mt-4 text-base text-slate-600 sm:text-lg">
           Tập trung vào những từ quan trọng nhất mỗi ngày cùng thẻ học trực quan, thống kê tối giản và nhắc học thông minh.
         </p>
-        <ul className="mt-6 space-y-3 text-sm text-slate-600">
-          {[
-            'Theo dõi tiến độ rõ ràng trên một bảng điều khiển duy nhất',
-            'Cấu trúc bài học ngắn gọn, phù hợp cho 15 phút mỗi ngày',
-            'Đồng bộ trên mọi thiết bị với tài khoản Google của bạn',
-          ].map((item) => (
-            <li key={item} className="flex items-start gap-3">
-              <span className="mt-1 h-2 w-2 rounded-full bg-slate-900" />
-              <span>{item}</span>
-            </li>
-          ))}
-        </ul>
+        <DailyMotivationQuote className="mt-8 w-full border-0 bg-slate-900/95 text-slate-100 shadow-xl shadow-slate-900/20" />
         <div className="mt-8 flex w-full flex-col gap-3 sm:flex-row sm:items-center">
           <Button
             size="lg"


### PR DESCRIPTION
## Summary
- add a reusable daily motivation quote component and supporting quote library
- surface the daily quote on the guest landing hero and authenticated dashboard while removing distracting marketing copy
- simplify the quote banner layout and fetch the daily message from the Google Books API with local caching and fallbacks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68de509ad7c083288dd2a5ef66f9ce17