### PR TITLE
Refine study session flow handling

### DIFF
--- a/ielts-vocabulary-app/frontend/src/pages/StudyPage.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/StudyPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/card';
 import { Button } from '../components/ui/button';
 import { Progress } from '../components/ui/progress';
@@ -15,11 +15,7 @@ const StudyPage: React.FC = () => {
   const [completed, setCompleted] = useState(0);
   const audioElementsRef = useRef<Record<string, HTMLAudioElement>>({});
 
-  useEffect(() => {
-    loadStudySessions();
-  }, []);
-
-  const loadStudySessions = async () => {
+  const loadStudySessions = useCallback(async () => {
     try {
       setLoading(true);
       const data = await userAPI.getDueVocabulary();
@@ -29,30 +25,37 @@ const StudyPage: React.FC = () => {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const handleAnswer = async (correct: boolean) => {
+  useEffect(() => {
+    loadStudySessions();
+  }, [loadStudySessions]);
+
+  const handleAnswer = useCallback(async (correct: boolean) => {
     const currentSession = sessions[currentIndex];
     if (!currentSession) return;
 
     try {
       await userAPI.updateProgress(currentSession.vocabulary._id, correct);
-      setCompleted(completed + 1);
-      
-      if (currentIndex < sessions.length - 1) {
-        setCurrentIndex(currentIndex + 1);
-        setShowAnswer(false);
-      } else {
-        // Study session completed
+      const isLastSession = currentIndex >= sessions.length - 1;
+
+      setCompleted((prev) => prev + 1);
+
+      if (isLastSession) {
         alert('Hoàn thành phiên học! Chúc mừng bạn!');
-        loadStudySessions(); // Reload for next session
+        await loadStudySessions();
         setCurrentIndex(0);
         setCompleted(0);
+        setShowAnswer(false);
+        return;
       }
+
+      setCurrentIndex((prev) => prev + 1);
+      setShowAnswer(false);
     } catch (error) {
       console.error('Error updating progress:', error);
     }
-  };
+  }, [currentIndex, sessions, loadStudySessions]);
 
   const speakWordWithSpeechSynthesis = useCallback((text: string) => {
     if ('speechSynthesis' in window) {
@@ -126,8 +129,20 @@ const StudyPage: React.FC = () => {
   }
 
   const currentSession = sessions[currentIndex];
-  const progress = ((completed) / sessions.length) * 100;
-  const illustrationUrl = resolveVocabularyImageUrl(currentSession.vocabulary);
+  const vocabulary = currentSession.vocabulary;
+
+  const progress = useMemo(() => {
+    if (!sessions.length) {
+      return 0;
+    }
+
+    return (completed / sessions.length) * 100;
+  }, [completed, sessions.length]);
+
+  const illustrationUrl = useMemo(
+    () => resolveVocabularyImageUrl(vocabulary),
+    [vocabulary],
+  );
 
   return (
     <div className="min-h-screen bg-gray-50 p-4">
@@ -146,29 +161,29 @@ const StudyPage: React.FC = () => {
           <CardHeader>
             <CardTitle className="flex items-center justify-between">
               <span className="text-3xl font-bold text-blue-600">
-                {currentSession.vocabulary.word}
+                {vocabulary.word}
               </span>
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => playPronunciation(currentSession.vocabulary)}
+                onClick={() => playPronunciation(vocabulary)}
               >
                 <Volume2 className="h-5 w-5" />
                 <span className="sr-only">Nghe phát âm</span>
               </Button>
             </CardTitle>
             <p className="text-lg text-gray-600">
-              {currentSession.vocabulary.pronunciation}
+              {vocabulary.pronunciation}
             </p>
             <p className="text-sm text-gray-500 font-medium">
-              {currentSession.vocabulary.partOfSpeech}
+              {vocabulary.partOfSpeech}
             </p>
           </CardHeader>
           <CardContent>
             <div className="mb-6 overflow-hidden rounded-2xl bg-gray-100 shadow-inner">
               <img
                 src={illustrationUrl}
-                alt={`Minh họa cho từ ${currentSession.vocabulary.word}`}
+                alt={`Minh họa cho từ ${vocabulary.word}`}
                 className="h-48 w-full object-cover"
                 loading="lazy"
                 onError={handleImageError}
@@ -185,19 +200,19 @@ const StudyPage: React.FC = () => {
               <div className="space-y-4">
                 <div>
                   <h3 className="font-semibold text-lg mb-2">Định nghĩa:</h3>
-                  <p className="text-gray-700">{currentSession.vocabulary.definition}</p>
+                  <p className="text-gray-700">{vocabulary.definition}</p>
                 </div>
 
                 <div>
                   <h3 className="font-semibold text-lg mb-2">Ví dụ:</h3>
-                  <p className="text-gray-700 italic">"{currentSession.vocabulary.example}"</p>
+                  <p className="text-gray-700 italic">"{vocabulary.example}"</p>
                 </div>
 
-                {currentSession.vocabulary.synonyms.length > 0 && (
+                {vocabulary.synonyms.length > 0 && (
                   <div>
                     <h3 className="font-semibold text-lg mb-2">Từ đồng nghĩa:</h3>
                     <div className="flex flex-wrap gap-2">
-                      {currentSession.vocabulary.synonyms.map((synonym, index) => (
+                      {vocabulary.synonyms.map((synonym, index) => (
                         <span
                           key={index}
                           className="bg-blue-100 text-blue-800 px-2 py-1 rounded text-sm"
@@ -209,11 +224,11 @@ const StudyPage: React.FC = () => {
                   </div>
                 )}
 
-                {currentSession.vocabulary.collocations.length > 0 && (
+                {vocabulary.collocations.length > 0 && (
                   <div>
                     <h3 className="font-semibold text-lg mb-2">Collocations:</h3>
                     <div className="space-y-2">
-                      {currentSession.vocabulary.collocations.map((collocation, index) => (
+                      {vocabulary.collocations.map((collocation, index) => (
                         <div key={index} className="bg-gray-50 p-3 rounded">
                           <p className="font-medium">{collocation.phrase}</p>
                           <p className="text-sm text-gray-600">{collocation.definition}</p>


### PR DESCRIPTION
## Summary
- convert study session loading into a memoized callback to avoid recreating functions on each render
- memoize derived vocabulary data and reuse it across the study card display
- update progress handling with functional state updates and reset logic for completed sessions

## Testing
- CI=true npm test -- --watch=false *(fails: Cannot find module 'react-router-dom' from 'src/App.tsx')*

------
https://chatgpt.com/codex/tasks/task_e_68de551439d08328ab8086a967d3cd12