### PR TITLE
Fix study streak reset logic

### DIFF
--- a/ielts-vocabulary-app/frontend/src/pages/home/LearningDashboard.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/LearningDashboard.tsx
@@ -6,7 +6,9 @@ import LearningSummary from './components/LearningSummary';
 import UpcomingReviews from './components/UpcomingReviews';
 import MasteryOverview from './components/MasteryOverview';
 import StudyPlanCard from './components/StudyPlanCard';
+import StudyStreakCard from './components/StudyStreakCard';
 import useDashboardData from './useDashboardData';
+import useStudyStreak from './useStudyStreak';
 
 interface LearningDashboardProps {
   user: User;
@@ -22,6 +24,7 @@ const LearningDashboard: React.FC<LearningDashboardProps> = ({
   onLogout,
 }) => {
   const { stats, dueVocabulary, levelDistribution, studyPlan, isLoading } = useDashboardData();
+  const { currentStreak, bestStreak, lastCheckIn, isCheckedInToday, checkIn } = useStudyStreak();
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -29,9 +32,16 @@ const LearningDashboard: React.FC<LearningDashboardProps> = ({
         <DashboardHeader user={user} onStartStudy={onStartStudy} onLogout={onLogout} />
         <DailyMotivationQuote className="border-0 bg-gradient-to-r from-indigo-500/90 to-sky-500/90 text-white shadow-lg shadow-indigo-200/40" />
         <LearningSummary stats={stats} />
-        <section className="grid gap-4 md:grid-cols-2">
+        <section className="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
           <StudyPlanCard plan={studyPlan} />
           <MasteryOverview distribution={levelDistribution} />
+          <StudyStreakCard
+            currentStreak={currentStreak}
+            bestStreak={bestStreak}
+            lastCheckIn={lastCheckIn}
+            isCheckedInToday={isCheckedInToday}
+            onCheckIn={checkIn}
+          />
         </section>
         <UpcomingReviews
           dueVocabulary={dueVocabulary}

--- a/ielts-vocabulary-app/frontend/src/pages/home/components/StudyStreakCard.tsx
+++ b/ielts-vocabulary-app/frontend/src/pages/home/components/StudyStreakCard.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { Flame } from 'lucide-react';
+import { Button } from '../../../components/ui/button';
+
+interface StudyStreakCardProps {
+  currentStreak: number;
+  bestStreak: number;
+  lastCheckIn: string | null;
+  isCheckedInToday: boolean;
+  onCheckIn: () => void;
+}
+
+const formatDate = (value: string | null) => {
+  if (!value) {
+    return 'Chưa có';
+  }
+
+  try {
+    const [year, month, day] = value.split('-').map(Number);
+    const date = new Date(year, (month ?? 1) - 1, day ?? 1);
+    return new Intl.DateTimeFormat('vi-VN', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    }).format(date);
+  } catch (error) {
+    console.error('Cannot format streak date', error);
+    return value;
+  }
+};
+
+const StudyStreakCard: React.FC<StudyStreakCardProps> = ({
+  currentStreak,
+  bestStreak,
+  lastCheckIn,
+  isCheckedInToday,
+  onCheckIn,
+}) => {
+  const message = (() => {
+    if (currentStreak === 0) {
+      return 'Bắt đầu chuỗi học của bạn bằng một check-in đầu tiên!';
+    }
+    if (isCheckedInToday) {
+      return 'Tuyệt vời! Bạn đã duy trì chuỗi học hôm nay.';
+    }
+    return 'Đừng bỏ lỡ chuỗi học, check-in ngay để giữ phong độ.';
+  })();
+
+  return (
+    <article className="flex h-full flex-col justify-between rounded-3xl bg-white p-6 shadow-sm">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-indigo-500">Chuỗi ngày học</p>
+          <h3 className="mt-2 text-2xl font-semibold text-slate-900">
+            {currentStreak} ngày liên tiếp
+          </h3>
+        </div>
+        <span className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-orange-50">
+          <Flame className="h-6 w-6 text-orange-500" />
+        </span>
+      </header>
+
+      <p className="mt-4 text-sm text-slate-600">{message}</p>
+
+      <div className="mt-6 flex items-end justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-slate-400">Kỷ lục</p>
+          <p className="text-lg font-semibold text-slate-900">{bestStreak} ngày</p>
+          <p className="mt-1 text-xs text-slate-400">
+            Lần check-in gần nhất: {formatDate(lastCheckIn)}
+          </p>
+        </div>
+        <Button onClick={onCheckIn} disabled={isCheckedInToday} className="shrink-0">
+          {isCheckedInToday ? 'Đã check-in hôm nay' : 'Check-in hôm nay'}
+        </Button>
+      </div>
+    </article>
+  );
+};
+
+export default StudyStreakCard;

--- a/ielts-vocabulary-app/frontend/src/pages/home/useStudyStreak.ts
+++ b/ielts-vocabulary-app/frontend/src/pages/home/useStudyStreak.ts
@@ -1,0 +1,135 @@
+import { useCallback, useEffect, useState } from 'react';
+
+interface StudyStreakState {
+  currentStreak: number;
+  bestStreak: number;
+  lastCheckIn: string | null;
+}
+
+const STORAGE_KEY = 'study-streak';
+
+const defaultState: StudyStreakState = {
+  currentStreak: 0,
+  bestStreak: 0,
+  lastCheckIn: null,
+};
+
+const getLocalDateString = (date: Date) => {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+const isPreviousDay = (referenceDate: string, currentDate: string) => {
+  const [year, month, day] = referenceDate.split('-').map(Number);
+  const reference = new Date(year, (month ?? 1) - 1, day ?? 1);
+  reference.setDate(reference.getDate() + 1);
+  return getLocalDateString(reference) === currentDate;
+};
+
+const useStudyStreak = () => {
+  const [state, setState] = useState<StudyStreakState>(defaultState);
+  const [isCheckedInToday, setIsCheckedInToday] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored) as Partial<StudyStreakState>;
+        const today = getLocalDateString(new Date());
+        const hydratedState: StudyStreakState = {
+          currentStreak: parsed.currentStreak ?? 0,
+          bestStreak: parsed.bestStreak ?? 0,
+          lastCheckIn: parsed.lastCheckIn ?? null,
+        };
+
+        const shouldResetStreak = (() => {
+          if (!hydratedState.lastCheckIn) {
+            return false;
+          }
+          if (hydratedState.lastCheckIn === today) {
+            return false;
+          }
+          return !isPreviousDay(hydratedState.lastCheckIn, today);
+        })();
+
+        const nextState: StudyStreakState = shouldResetStreak
+          ? { ...hydratedState, currentStreak: 0 }
+          : hydratedState;
+
+        if (shouldResetStreak) {
+          try {
+            localStorage.setItem(STORAGE_KEY, JSON.stringify(nextState));
+          } catch (error) {
+            console.error('Failed to update study streak after reset', error);
+          }
+        }
+
+        setState(nextState);
+        setIsCheckedInToday(nextState.lastCheckIn === today);
+      } else {
+        setState(defaultState);
+        setIsCheckedInToday(false);
+      }
+    } catch (error) {
+      console.error('Failed to load study streak from storage', error);
+      setState(defaultState);
+      setIsCheckedInToday(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const today = getLocalDateString(new Date());
+    setIsCheckedInToday(state.lastCheckIn === today);
+  }, [state.lastCheckIn]);
+
+  const checkIn = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    setState((previous) => {
+      const today = getLocalDateString(new Date());
+
+      if (previous.lastCheckIn === today) {
+        setIsCheckedInToday(true);
+        return previous;
+      }
+
+      let currentStreak = 1;
+      if (previous.lastCheckIn && isPreviousDay(previous.lastCheckIn, today)) {
+        currentStreak = previous.currentStreak + 1;
+      }
+
+      const nextState: StudyStreakState = {
+        currentStreak,
+        bestStreak: Math.max(currentStreak, previous.bestStreak),
+        lastCheckIn: today,
+      };
+
+      try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(nextState));
+      } catch (error) {
+        console.error('Failed to save study streak to storage', error);
+      }
+
+      setIsCheckedInToday(true);
+      return nextState;
+    });
+  }, []);
+
+  return {
+    currentStreak: state.currentStreak,
+    bestStreak: state.bestStreak,
+    lastCheckIn: state.lastCheckIn,
+    isCheckedInToday,
+    checkIn,
+  };
+};
+
+export default useStudyStreak;


### PR DESCRIPTION
## Summary
- add a study streak hook that persists streak data in localStorage
- display a study streak card on the learning dashboard with daily check-in messaging
- integrate the streak tracker alongside existing mastery and study plan insights
- reset the stored streak when the last check-in is not today or yesterday so missed days break the streak

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68de5aa184c08328ba3aa9cbdd2fc159